### PR TITLE
User seeing the "Previous" button in black color

### DIFF
--- a/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
@@ -249,6 +249,12 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     showPage: function(page_no) {
         var instance = this;
         EkstepRendererAPI.dispatchEvent("sceneEnter", context);
+        $('.nav-previous').addClass('higheropacity');
+        if(page_no == 1) {
+            $('.nav-previous').removeClass('higheropacity');
+            $('.nav-previous').addClass('loweropacity');
+        }
+
         if (page_no <= context.TOTAL_PAGES && page_no > 0) {
 
             context.PAGE_RENDERING_IN_PROGRESS = 1;


### PR DESCRIPTION
**Description**:
User seeing the "Previous" button in black color, should display gray color when pdf content load first page.

**Test Cases and Scenarios:**
https://project-sunbird.atlassian.net/browse/SB-4958