### PR TITLE
#SB-0000: Telemetry duration bug fixes (Converting miliSeconds to sec…

### DIFF
--- a/js-libs/telemetry-lib/telemetryV3Interface.js
+++ b/js-libs/telemetry-lib/telemetryV3Interface.js
@@ -84,7 +84,7 @@ var EkTelemetry = (function() {
      * @param  {object} options    [It can have `context, object, actor` can be explicitly passed in this event]
      */
     this.ektelemetry.start = function(config, contentId, contentVer, data, options) {
-        data.duration = data.duration || (new Date()).getTime();
+        data.duration = data.duration || ((new Date()).getTime()) * 0.001; // Converting duration miliSeconds to seconds
         if(contentId && contentVer){
             telemetryInstance._globalObject.id =  contentId;
             telemetryInstance._globalObject.ver = contentVer;
@@ -262,7 +262,7 @@ var EkTelemetry = (function() {
     this.ektelemetry.end = function(data, options) {
         if(telemetryInstance.startData.length){
             var startEventObj = telemetryInstance.startData.pop();
-            data.duration = ((new Date()).getTime() - startEventObj.ets)
+            data.duration = ((new Date()).getTime() - startEventObj.ets) * 0.001; // Converting duration miliSeconds to seconds
             instance.updateValues(options);
             instance._dispatch(instance.getEvent('END', data));
         }else{

--- a/js-libs/telemetry-lib/telemetryV3Interface.js
+++ b/js-libs/telemetry-lib/telemetryV3Interface.js
@@ -84,7 +84,7 @@ var EkTelemetry = (function() {
      * @param  {object} options    [It can have `context, object, actor` can be explicitly passed in this event]
      */
     this.ektelemetry.start = function(config, contentId, contentVer, data, options) {
-        data.duration = data.duration || ((new Date()).getTime()) * 0.001; // Converting duration miliSeconds to seconds
+        data.duration = data.duration || (((new Date()).getTime()) * 0.001); // Converting duration miliSeconds to seconds
         if(contentId && contentVer){
             telemetryInstance._globalObject.id =  contentId;
             telemetryInstance._globalObject.ver = contentVer;


### PR DESCRIPTION
@pallakartheekreddy  @vinukumar-vs 

Issue link: https://project-sunbird.atlassian.net/browse/SB-6848

This patch is related to telemetry duration issue, Currently telemetry lib is generating a wrong duration value for both start and end event.
As per the telemetry spec duration should log in the format of second  so converted from milliseconds to seconds.

Please let me know if any changes are needed.

 