### PR TITLE
#SB-6848 fix: Telemetry duration issue fix in both START and END Events

### DIFF
--- a/js-libs/telemetry-lib/telemetryV3Interface.js
+++ b/js-libs/telemetry-lib/telemetryV3Interface.js
@@ -84,7 +84,7 @@ var EkTelemetry = (function() {
      * @param  {object} options    [It can have `context, object, actor` can be explicitly passed in this event]
      */
     this.ektelemetry.start = function(config, contentId, contentVer, data, options) {
-        data.duration = data.duration || (((new Date()).getTime()) * 0.001); // Converting duration miliSeconds to seconds
+        data.duration = data.duration || 0 // Default Duration of Start Event is 0
         if(contentId && contentVer){
             telemetryInstance._globalObject.id =  contentId;
             telemetryInstance._globalObject.ver = contentVer;

--- a/js-libs/telemetry/TelemetryV3Manager.js
+++ b/js-libs/telemetry/TelemetryV3Manager.js
@@ -48,6 +48,7 @@ TelemetryV3Manager = Class.extend({
         if(data.loc){
           edata["loc"] = data.loc;
         }
+        edata.duration = data.duration;
         var actorObj = {"actor" : { id: config.uid, type: "User" } };
         EkTelemetry.start(config, TelemetryService._gameData.id, ver, edata, actorObj);
     },

--- a/player/public/coreplugins/org.ekstep.ecmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.ecmlrenderer-1.0/renderer/plugin.js
@@ -255,6 +255,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     },
     replay: function(){
         if (this.sleepMode) return;
+        EkstepRendererAPI.updatePlayerStartTime();
         this.qid = [];
         this.stageId = [];
         if (Renderer && Renderer.theme) {

--- a/player/public/coreplugins/org.ekstep.epubrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.epubrenderer-1.0/renderer/plugin.js
@@ -118,6 +118,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     },
     replay:function(){
         if (this.sleepMode) return;
+        EkstepRendererAPI.updatePlayerStartTime();
         this.stageId = [];
         this.lastPage = false;
         this.currentPage = 1;

--- a/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
@@ -69,6 +69,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     },
     replay: function() {
         if (this.sleepMode) return;
+        EkstepRendererAPI.updatePlayerStartTime();
         this._super();
         this.enableOverly();
     },

--- a/player/public/coreplugins/org.ekstep.videorenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.videorenderer-1.0/renderer/plugin.js
@@ -189,6 +189,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     },
     replay:function(){
         if (this.sleepMode) return;
+       EkstepRendererAPI.updatePlayerStartTime(); 
        EkstepRendererAPI.dispatchEvent('renderer:overlay:unmute');
        this.start();
     },

--- a/player/public/js/baseLauncher.js
+++ b/player/public/js/baseLauncher.js
@@ -76,6 +76,7 @@ org.ekstep.contentrenderer.baseLauncher = Class.extend({
      */
     replay: function() {
         if (this.sleepMode) return;
+        EkstepRendererAPI.updatePlayerStartTime();
         this.heartBeatEvent(false);
         this.endTelemetry();
         this.start();
@@ -115,6 +116,7 @@ org.ekstep.contentrenderer.baseLauncher = Class.extend({
         data.mode = getPreviewMode();
         var gameId = TelemetryService.getGameId();
         var version = TelemetryService.getGameVer();
+        data.duration = (Date.now() - EkstepRendererAPI.getPlayerStartTime()) * 0.001;
         TelemetryService.start(gameId, version, data);
     },
 

--- a/player/public/js/content-renderer.js
+++ b/player/public/js/content-renderer.js
@@ -13,6 +13,7 @@ window.globalConfig = {
     'context': {},
     'config': {}
 };
+window.PLAYER_START_TIME = Date.now();
 org.ekstep.contentrenderer.init = function() {
     window.initializePreview = org.ekstep.contentrenderer.initializePreview;
     window.setContentData = org.ekstep.contentrenderer.setContent;

--- a/player/public/js/ekstepRendererApi.js
+++ b/player/public/js/ekstepRendererApi.js
@@ -1069,5 +1069,20 @@ window.EkstepRendererAPI = {
      */
     isAudioMuted: function(){
         return AudioManager.muted;
+    },
+
+    /**
+     * Which returns the player start time
+     * @return {int} Current time in miliseconds
+     */
+    getPlayerStartTime:function(){
+        return window.PLAYER_START_TIME;
+    },
+
+    /**
+     * Which updates the PLAYER_START_TIME to current time in miliseconds
+     */
+    updatePlayerStartTime:function(){
+        window.PLAYER_START_TIME = Date.now()
     }
 }


### PR DESCRIPTION
**Scenario**

- [x] In both start and end event should log an duration in the format of `seconds`

- [x] START Event Duration should be accurate.(Time taken to initiate the player in seconds) 

- [x] END Event Duration should be accurate.(Time take to finish the content in seconds)

- [x] On content replay also should calculate the accurate duration for both start and end event

- [x] Verified content types
      
 *  ECML, HTML, Epub, Youtube, Pdf, h5p  


**Note: Due to i was unable to edit the jira issue so i have updated my scenarios here**


@pallakartheekreddy  @vinukumar-vs 

