### PR TITLE
content-player npm package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,49 @@
-# Genie-Canvas
-Genie Canvas : Quiz/Story App
+# Content Player
 
-### Setup of Genie-Canvas:
+![](https://api.travis-ci.org/project-sunbird/sunbird-content-player.svg?branch=master)
 
-* Install android-sdk.
-* Install npm.
-* Install cordova and ionic framwork.
-* Install grunt.
+## What is Content Player?
+  // Description
+   
+ **Supported Contents**
+   
+  * ECML (Ekstep content markup language)
+  * HTML
+  * Youtube
+  * Epub
+  * H5P
+  * Mp4/Webm
+  * PDF
 
-### How to build:
-* Clone the project.
-* Change to PROJECT_FOLDER/player (cd player)
-* Run `npm install`
-* Run `grunt init-setup`
-* Run `grunt build-aar` - to build normal aar files.
-* Run `grunt build-aar-xwalk` - to build xwalk aar files.
 
-The .aar files are created at the below path.
+## Prerequisites
+    
+   * Install NPM, Node(v6), android-sdk, Cordova and Ionic
 
-PROJECT_FOLDER/player/platforms/android/build/outputs/aar/geniecanvas-BUILD_NUMBER-debug.aar
-PROJECT_FOLDER/player/platforms/android/CordovaLib/build/outputs/aar/CordovaLib-debug.aar
+## How to run 
+
+* Clone the content player from here
+* Run `npm install` in PROJECT_FOLDER/player path
+* To run player in local `node app`
+
+## How to build
+    
+   1. **Preview**
+      
+      Run `npm run build-preview sunbird` which creates the preview folder for sunbird instance
+      
+ 2. **AAR**
+ 
+ 	Run `npm run build-aar sunbird` which creates an aar file for the sunbird instance
+ 	
+ The AAR file will create in the below path.
+ 
+> PROJECT_FOLDER/player/platforms/android/build/outputs/aar/geniecanvas-BUILD_NUMBER-debug.aar
+ 
+
+## Reporting Issues
+We have an open and active [issue tracker](https://github.com/project-sunbird/sunbird-commons/issues). Please report any issues.
+
+
+
+

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ var previewObj = {
 | `apislug` | It is `string` which defines proxy setup to make a api request | ```/action```
 
 
-1. **[How to render in Web environment](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)**
+1. **How to render in Web**
 
     content player will render inside the web environment with the above configuration .
     
@@ -126,6 +126,7 @@ var previewObj = {
 	
 	```
 	**JS**
+	
 	```js
 	
 	  var previewElement = jQuery('#preview')[0];
@@ -134,17 +135,11 @@ var previewObj = {
       }
 	
 	```
- 
+2. **How to render in Device(cordova)**
 
-For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)
-    
+content player will render inside Cordova environment and it's accepting the configuration through ```cordova webintent```
 
 
-2. **[How to render in Device environment(cordova)](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)**
-
-content player will render inside Cordova environment and it's accepting the configuration through the cordova webintent
-
-For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)
 
 
 

--- a/README.md
+++ b/README.md
@@ -19,71 +19,75 @@
 
 Content player is a customisable and configurable before launching any type of content inside any environment (preview or device) it expecting few configurations. Based on the configuration content will be rendered in the respective environment. 
 
+Download content player preview from NPM
+
+> Run npm i @project-sunbird/content-player
+
+	
+
 **Preview object**     
 
 ```js
 var previewObj = {
-	"context": {
-		"mode": "preview/edit/play",  // to identify preview used by the user to play/edit/preview
-                "authToken":"",// Auth key to make V3 api calls
-		"contentId": "do_201734893",   // ContentId used to get body data from content API call
-		"sid": "sdjfo8e-3ndofd3-3nhfo334" // User sessionid on portal or mobile
-		"did": "sdjfo8e-3ndofd3-3nhfo334" // Unique id to identify the device or browser 
-		"uid": "sdjfo8e-3ndofd3-3nhfo334" // Current logged in user id
-		"channel": "" // To identify the channel(Channel ID). Default value ""
-		"pdata": // Producer information. Generally the App which is creating the event, default value {}
-		{ 
-		  "id": "", // Producer ID. For ex: For sunbird it would be "portal" or "genie"
-                  "pid": , // Optional. In case the component is distributed, then which instance of that component
-		  "ver": "", // version of the App
-		}, 
-		"app": [""], // Genie tags
-		"partner": [""], // Partner tags
-		"dims": [""], // Encrypted dimension tags passed by respective channels
-		"cdata": [{ //correlation data
-		  * "type":"" //Used to indicate action that is being correlated
-		  "id": "" //The correlation ID value
-		}],
+    "context": {
+        "mode": "preview/edit/play", // to identify preview used by the user to play/edit/preview
+        "authToken": "", // Auth key to make V3 api calls
+        "contentId": "do_201734893", // ContentId used to get body data from content API call
+        "sid": "sdjfo8e-3ndofd3-3nhfo334", // User sessionid on portal or mobile
+        "did": "sdjfo8e-3ndofd3-3nhfo334", // Unique id to identify the device or browser 
+        "uid": "sdjfo8e-3ndofd3-3nhfo334", // Current logged in user id
+        "channel": "", // To identify the channel(Channel ID). Default value ""
+        "pdata": // Producer information. Generally the App which is creating the event, default value {}
+        {
+            "id": "", // Producer ID. For ex: For sunbird it would be "portal" or "genie"
+            "pid": "", // Optional. In case the component is distributed, then which instance of that component
+            "ver": "", // version of the App
+        },
+        "app": [""], // Genie tags
+        "partner": [""], // Partner tags
+        "dims": [""], // Encrypted dimension tags passed by respective channels
+        "cdata": [{ //correlation data
+            "type": "", //Used to indicate action that is being correlated
+            "id": "" //The correlation ID value
+        }],
 
-	},
-	"config": {
-		"repos": ["s3path"],    // plugins repo path where all the plugins are pushed s3 or absolute folder path
-		"plugins": [{id:"org.sunbird.telemtryPlugin", "ver": "1.0", "type":"plugin"}],     //Inject external custom plugins into content (for externl telemetry sync)
-		"overlay": {  // Configuarable propeties of overlay showing by GenieCanvas on top of the content
-		  "enableUserSwitcher": true, // enable/disable user-switcher, default is true for mobile & preview
-		  "showUser": true,     // show/hide user-switcher functionality. default is true to show user information
-		  "showOverlay": true,  // show/hide complete overlay including next/previous buttons. default value true
-		  "showNext": true,     // show/hide next navigation button on content. default is true
-		  "showPrevious": true, // show/hide previous navigation button on content. default is true
-		  "showSubmit": false,  // show/hide submit button for assessmetns in the content. default is false
-		  "showReload": true,   // show/hide stage reload button to reset/re-render the stage. default is true
-		  "menu": {
-		    "showTeachersInstruction": true  // show/hide teacher instructions in the menu
-		  }
-		},
-		"splash": {  // list of configurable properties to handle splash screen shown while loading content
-		  "text": "Powered by Sunbird",  // Text to be shown on splash screen while loading content. 
-		  "icon": "assets/icons/icn_genie.png",  // Icon to be show on above the text(full absolute path of the image in mobiew or http image link)
-		  "bgImage": "assets/icons/background_1.png",  // backgroung image used for splash screen while loading content(absolute folder path of the image in mobie or http image link)
-		  "webLink": "XXXX"  // weblink to be opened on click of text
-		},
-		"mimetypes": [  // Content mimetypes for new cotent lucnhers
-		  "application/vnd.ekstep.ecml-archive", 
-		  "application/vnd.ekstep.html-archive"
-		],
-		"contentLaunchers": [ // content laucher plugins for specific content mimetypes
-		  {  // Plugin used for ECML content to launch, It is default plugin
-		    "mimeType": 'application/vnd.ekstep.html-archive',
-		    "id": 'org.sunbird.htmlrenderer',
-		    "ver": 1.0,
-		    "type": 'plugin'
-		  },
-		  ...
-		]
-		... (any addition data used by plugins injecting to preview)
-	},
-	"metadata": {},  //content metadata json object (from API response take -> response.result.content)
-	"data": undefined     // content body json object (from API response take -> response.result.content.body)
+    },
+    "config": {
+        "repos": ["s3path"], // plugins repo path where all the plugins are pushed s3 or absolute folder path
+        "plugins": [{ id: "org.sunbird.telemtryPlugin", "ver": "1.0", "type": "plugin" }], //Inject external custom plugins into content (for externl telemetry sync)
+        "overlay": { // Configuarable propeties of overlay showing by GenieCanvas on top of the content
+            "enableUserSwitcher": true, // enable/disable user-switcher, default is true for mobile & preview
+            "showUser": true, // show/hide user-switcher functionality. default is true to show user information
+            "showOverlay": true, // show/hide complete overlay including next/previous buttons. default value true
+            "showNext": true, // show/hide next navigation button on content. default is true
+            "showPrevious": true, // show/hide previous navigation button on content. default is true
+            "showSubmit": false, // show/hide submit button for assessmetns in the content. default is false
+            "showReload": true, // show/hide stage reload button to reset/re-render the stage. default is true
+            "menu": {
+                "showTeachersInstruction": true // show/hide teacher instructions in the menu
+            }
+        },
+        "splash": { // list of configurable properties to handle splash screen shown while loading content
+            "text": "Powered by Sunbird", // Text to be shown on splash screen while loading content. 
+            "icon": "assets/icons/icn_genie.png", // Icon to be show on above the text(full absolute path of the image in mobiew or http image link)
+            "bgImage": "assets/icons/background_1.png", // backgroung image used for splash screen while loading content(absolute folder path of the image in mobie or http image link)
+            "webLink": "XXXX" // weblink to be opened on click of text
+        },
+        "mimetypes": [ // Content mimetypes for new cotent lucnhers
+            "application/vnd.ekstep.ecml-archive",
+            "application/vnd.ekstep.html-archive"
+        ],
+        "contentLaunchers": [ // content laucher plugins for specific content mimetypes
+            { // Plugin used for ECML content to launch, It is default plugin
+                "mimeType": 'application/vnd.ekstep.html-archive',
+                "id": 'org.sunbird.htmlrenderer',
+                "ver": 1.0,
+                "type": 'plugin'
+            }
+        ]
+    },
+    "metadata": {}, //content metadata json object (from API response take -> response.result.content)
+    "data": undefined // content body json object (from API response take -> response.result.content.body)
 }
 
 
@@ -111,13 +115,26 @@ var previewObj = {
 
 1. **[How to render in Web environment](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)**
 
-    Canvas will render inside the web environment it accepting above configuration these configurations should send through initializePreview.
+    content player will render inside the web environment with the above configuration .
+    
+	**HTML**
+	
+	```html
+	<div class="content-player">
+	    <iframe id="preview" src ='./node_modules/@project-sunbird/content-player/preview.html?webview=true' width=100% height=100%></iframe>
+   </div>
+	
+	```
+	**JS**
+	```js
+	
+	  var previewElement = jQuery('#preview')[0];
+      previewElement.onload = function() {
+           previewContentIframe.contentWindow.initializePreview(configuration);
+      }
+	
+	```
  
-```js
-
-window.initializePreview(config)  
-
-```
 
 For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)
     
@@ -125,7 +142,7 @@ For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/G
 
 2. **[How to render in Device environment(cordova)](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)**
 
-Canvas will render inside Cordova environment and it's accepting the configuration through the cordova webintent
+content player will render inside Cordova environment and it's accepting the configuration through the cordova webintent
 
 For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![](https://api.travis-ci.org/project-sunbird/sunbird-content-player.svg?branch=master)
 
 ## What is Content Player?
-  // Description
+  Which renders the contents in both device and web
    
  **Supported Contents**
    
@@ -32,7 +32,7 @@
       
       Run `npm run build-preview sunbird` which creates the preview folder for sunbird instance
       
- 2. **AAR**
+   2. **AAR**
  
  	Run `npm run build-aar sunbird` which creates an aar file for the sunbird instance
  	
@@ -42,7 +42,7 @@
  
 
 ## Reporting Issues
-We have an open and active [issue tracker](https://github.com/project-sunbird/sunbird-commons/issues). Please report any issues.
+We have an open and active [issue tracker](https://github.com/ekstep/Field-Issues/issues). Please report any issues.
 
 
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ var previewObj = {
 		"channel": "" // To identify the channel(Channel ID). Default value ""
 		"pdata": // Producer information. Generally the App which is creating the event, default value {}
 		{ 
-		  "id": "", // Producer ID. For ex: For ekstep it would be "portal" or "genie"
+		  "id": "", // Producer ID. For ex: For sunbird it would be "portal" or "genie"
                   "pid": , // Optional. In case the component is distributed, then which instance of that component
 		  "ver": "", // version of the App
 		}, 
@@ -48,7 +48,7 @@ var previewObj = {
 	},
 	"config": {
 		"repos": ["s3path"],    // plugins repo path where all the plugins are pushed s3 or absolute folder path
-		"plugins": [{id:"org.ekstep.telemtryPlugin", "ver": "1.0", "type":"plugin"}],     //Inject external custom plugins into content (for externl telemetry sync)
+		"plugins": [{id:"org.sunbird.telemtryPlugin", "ver": "1.0", "type":"plugin"}],     //Inject external custom plugins into content (for externl telemetry sync)
 		"overlay": {  // Configuarable propeties of overlay showing by GenieCanvas on top of the content
 		  "enableUserSwitcher": true, // enable/disable user-switcher, default is true for mobile & preview
 		  "showUser": true,     // show/hide user-switcher functionality. default is true to show user information
@@ -62,10 +62,10 @@ var previewObj = {
 		  }
 		},
 		"splash": {  // list of configurable properties to handle splash screen shown while loading content
-		  "text": "Powered by EkStep",  // Text to be shown on splash screen while loading content. 
+		  "text": "Powered by Sunbird",  // Text to be shown on splash screen while loading content. 
 		  "icon": "assets/icons/icn_genie.png",  // Icon to be show on above the text(full absolute path of the image in mobiew or http image link)
 		  "bgImage": "assets/icons/background_1.png",  // backgroung image used for splash screen while loading content(absolute folder path of the image in mobie or http image link)
-		  "webLink": "https://www.ekstep.in"  // weblink to be opened on click of text
+		  "webLink": "XXXX"  // weblink to be opened on click of text
 		},
 		"mimetypes": [  // Content mimetypes for new cotent lucnhers
 		  "application/vnd.ekstep.ecml-archive", 
@@ -74,7 +74,7 @@ var previewObj = {
 		"contentLaunchers": [ // content laucher plugins for specific content mimetypes
 		  {  // Plugin used for ECML content to launch, It is default plugin
 		    "mimeType": 'application/vnd.ekstep.html-archive',
-		    "id": 'org.ekstep.htmlrenderer',
+		    "id": 'org.sunbird.htmlrenderer',
 		    "ver": 1.0,
 		    "type": 'plugin'
 		  },
@@ -150,11 +150,11 @@ For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/G
     
    1. **Preview**
       
-      Run `npm run build-preview sunbird` which creates the preview folder for sunbird instance
+     	Run `npm run build-preview sunbird` which creates the preview folder for sunbird instance
       
    2. **AAR**
    
- Run  `npm run build-aar sunbird`  which creates an aar file for the sunbird instance
+ 		Run  `npm run build-aar sunbird`  which creates an aar file for the sunbird instance
  	
  The AAR file will create in the below path.
  
@@ -162,7 +162,7 @@ For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/G
  
 
 ## Any Issues ?
-We have an open and active [issue tracker](https://github.com/ekstep/Field-Issues/issues). Please report any issues.
+We have an open and active [issue tracker](https://github.com/Field-Issues/issues). Please report any issues.
 
 
 

--- a/README.md
+++ b/README.md
@@ -15,18 +15,138 @@
   * Mp4/Webm
   * PDF
 
+## How to render the contents?
 
-## Prerequisites
+Content player is a customisable and configurable before launching any type of content inside any environment (preview or device) it expecting few configurations. Based on the configuration content will be rendered in the respective environment. 
+
+**Preview object**     
+
+```js
+var previewObj = {
+	"context": {
+		"mode": "preview/edit/play",  // to identify preview used by the user to play/edit/preview
+                "authToken":"",// Auth key to make V3 api calls
+		"contentId": "do_201734893",   // ContentId used to get body data from content API call
+		"sid": "sdjfo8e-3ndofd3-3nhfo334" // User sessionid on portal or mobile
+		"did": "sdjfo8e-3ndofd3-3nhfo334" // Unique id to identify the device or browser 
+		"uid": "sdjfo8e-3ndofd3-3nhfo334" // Current logged in user id
+		"channel": "" // To identify the channel(Channel ID). Default value ""
+		"pdata": // Producer information. Generally the App which is creating the event, default value {}
+		{ 
+		  "id": "", // Producer ID. For ex: For ekstep it would be "portal" or "genie"
+                  "pid": , // Optional. In case the component is distributed, then which instance of that component
+		  "ver": "", // version of the App
+		}, 
+		"app": [""], // Genie tags
+		"partner": [""], // Partner tags
+		"dims": [""], // Encrypted dimension tags passed by respective channels
+		"cdata": [{ //correlation data
+		  * "type":"" //Used to indicate action that is being correlated
+		  "id": "" //The correlation ID value
+		}],
+
+	},
+	"config": {
+		"repos": ["s3path"],    // plugins repo path where all the plugins are pushed s3 or absolute folder path
+		"plugins": [{id:"org.ekstep.telemtryPlugin", "ver": "1.0", "type":"plugin"}],     //Inject external custom plugins into content (for externl telemetry sync)
+		"overlay": {  // Configuarable propeties of overlay showing by GenieCanvas on top of the content
+		  "enableUserSwitcher": true, // enable/disable user-switcher, default is true for mobile & preview
+		  "showUser": true,     // show/hide user-switcher functionality. default is true to show user information
+		  "showOverlay": true,  // show/hide complete overlay including next/previous buttons. default value true
+		  "showNext": true,     // show/hide next navigation button on content. default is true
+		  "showPrevious": true, // show/hide previous navigation button on content. default is true
+		  "showSubmit": false,  // show/hide submit button for assessmetns in the content. default is false
+		  "showReload": true,   // show/hide stage reload button to reset/re-render the stage. default is true
+		  "menu": {
+		    "showTeachersInstruction": true  // show/hide teacher instructions in the menu
+		  }
+		},
+		"splash": {  // list of configurable properties to handle splash screen shown while loading content
+		  "text": "Powered by EkStep",  // Text to be shown on splash screen while loading content. 
+		  "icon": "assets/icons/icn_genie.png",  // Icon to be show on above the text(full absolute path of the image in mobiew or http image link)
+		  "bgImage": "assets/icons/background_1.png",  // backgroung image used for splash screen while loading content(absolute folder path of the image in mobie or http image link)
+		  "webLink": "https://www.ekstep.in"  // weblink to be opened on click of text
+		},
+		"mimetypes": [  // Content mimetypes for new cotent lucnhers
+		  "application/vnd.ekstep.ecml-archive", 
+		  "application/vnd.ekstep.html-archive"
+		],
+		"contentLaunchers": [ // content laucher plugins for specific content mimetypes
+		  {  // Plugin used for ECML content to launch, It is default plugin
+		    "mimeType": 'application/vnd.ekstep.html-archive',
+		    "id": 'org.ekstep.htmlrenderer',
+		    "ver": 1.0,
+		    "type": 'plugin'
+		  },
+		  ...
+		]
+		... (any addition data used by plugins injecting to preview)
+	},
+	"metadata": {},  //content metadata json object (from API response take -> response.result.content)
+	"data": undefined     // content body json object (from API response take -> response.result.content.body)
+}
+
+
+```
+**Description**
+
+
+| Property Name | Description | Default Value   |
+| --- | --- | --- |
+| `host` | It is a `string` which defines the from which domain content should be load|```window.location.origin```  |
+| `mimetypes` | It is an `array` which defines the what type of the content to be renderer| ```[ ]```|
+| `contentLaunchers` | It is an `array` of plugin objects it will launch the content based on the mimeType which is defined| ``` []```|
+| `overlay` | It is an `object` using this canvas overlay can be customized based on the flags| ```{}```|
+| `splash` | It is an `object` before launching any type of content splash screen will load and it is customizable |```{}```|
+| `showEndpage` | It is `boolean` which defines should default canvas endpage should load or not | ```TRUE```
+| `pdata` | It is an `object` which defines the producer information it should have identifier and version and canvas will log in the telemetry| ```{'id':'in.ekstep', 'ver':'1.0'}```|
+| `channel` | It is `string` which defines channel identifier to know which channel is currently using.| `in.ekstep` |
+| `app` | It is an `array` which defines the app tags and canvas will log in the telemetry| ```[]``` |
+| `partner` | It is an `array` which defines the partner tags and canvas will log in the telemetry|```[]``` |
+| `dims` | It is an `array` which defines the encrypted dimension tags it should be passed from the respective channel and canvas will log in the telemetry|```[]```  |
+| `context` | It is an `object` it contains the `uid`,`did`,`sid`,`mode` etc., these will be logged inside the telemetry  | ```{}``` |
+| `config` | It is an `object` it contains the `repo`,`plugins`,`overlay`,`splash` etc., these will be used to configure the canvas  | ```{}```
+| `apislug` | It is `string` which defines proxy setup to make a api request | ```/action```
+
+
+1. **[How to render in Web environment](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)**
+
+    Canvas will render inside the web environment it accepting above configuration these configurations should send through initializePreview.
+ 
+```js
+
+window.initializePreview(config)  
+
+```
+
+For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-embed-or-render-content-preview-in-portal-or-editor-or-external-consumer)
+    
+
+
+2. **[How to render in Device environment(cordova)](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)**
+
+Canvas will render inside Cordova environment and it's accepting the configuration through the cordova webintent
+
+For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/GenieCanvas:-How-to-render-content--in-app)
+
+
+
+
+
+## How to setup content player in local
+
+
+ **Prerequisites**
     
    * Install NPM, Node(v6), android-sdk, Cordova and Ionic
 
-## How to run 
+ **How to Run**
 
 * Clone the content player from here
 * Run `npm install` in PROJECT_FOLDER/player path
 * To run player in local `node app`
 
-## How to build
+ **How to build**
     
    1. **Preview**
       
@@ -41,7 +161,7 @@
 > PROJECT_FOLDER/player/platforms/android/build/outputs/aar/geniecanvas-BUILD_NUMBER-debug.aar
  
 
-## Reporting Issues
+## Any Issues ?
 We have an open and active [issue tracker](https://github.com/ekstep/Field-Issues/issues). Please report any issues.
 
 

--- a/README.md
+++ b/README.md
@@ -153,8 +153,8 @@ For more info please refer [here](https://github.com/ekstep/Common-Design/wiki/G
       Run `npm run build-preview sunbird` which creates the preview folder for sunbird instance
       
    2. **AAR**
- 
- 	Run `npm run build-aar sunbird` which creates an aar file for the sunbird instance
+   
+ Run  `npm run build-aar sunbird`  which creates an aar file for the sunbird instance
  	
  The AAR file will create in the below path.
  

--- a/player/package.json
+++ b/player/package.json
@@ -1,7 +1,7 @@
 {
-    "name": "quizapp",
+    "name": "content-player",
     "version": "1.0.0",
-    "description": "quizApp: An Ionic project",
+    "description": "Which renders the contents in both web and devices",
     "dependencies": {
         "async": "*",
         "audiosprite": "*",
@@ -81,12 +81,15 @@
         "replace-in-file": "3.4.2",
         "replace": "1.0.0",
         "on-build-webpack": "0.1.0",
-        "fs-extra": "7.0.0"
+        "fs-extra": "7.0.0",
+        "if-env": "1.0.4"
     },
     "scripts": {
         "build-sunbird": "webpack --env.channel=sunbird",
         "build-ekstep": "webpack --env.channel=ekstep",
-        "package-coreplugins": "webpack --config webpack.plugin.config.js"
+        "package-coreplugins": "webpack --config webpack.plugin.config.js",
+        "build-preview": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-preview; else echo ${1} npm run package-coreplugins && npm run build-sunbird && grunt build-preview; fi' -- ",
+        "build-aar": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-app; else npm run package-coreplugins && npm run build-sunbird && grunt build-app; fi' -- "
     },
     "cordovaPlugins": [
         "cordova-plugin-device",

--- a/player/package.json
+++ b/player/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/content-player",
-    "version": "1.0.0",
+    "version": "0.0.2",
     "description": "Which renders the contents in both web and devices",
     "dependencies": {
         "async": "*",
@@ -93,7 +93,6 @@
         "build-preview": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-preview; else echo ${1} npm run package-coreplugins && npm run build-sunbird && grunt build-preview; fi' -- ",
         "build-aar": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-app; else npm run package-coreplugins && npm run build-sunbird && grunt build-app; fi' -- ",
         "build-npm-package": "node_modules/.bin/rimraf ./www && npm run build-preview sunbird && node_modules/.bin/cpy package.json ./www/preview && node_modules/.bin/cpy ../README.md ./www/preview"
-
     },
     "cordovaPlugins": [
         "cordova-plugin-device",

--- a/player/package.json
+++ b/player/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "content-player",
+    "name": "@project-sunbird/content-player",
     "version": "1.0.0",
     "description": "Which renders the contents in both web and devices",
     "dependencies": {
@@ -82,14 +82,18 @@
         "replace": "1.0.0",
         "on-build-webpack": "0.1.0",
         "fs-extra": "7.0.0",
-        "if-env": "1.0.4"
+        "if-env": "1.0.4",
+        "rimraf": "2.6.2",
+        "cpy-cli": "2.0.0"
     },
     "scripts": {
         "build-sunbird": "webpack --env.channel=sunbird",
         "build-ekstep": "webpack --env.channel=ekstep",
         "package-coreplugins": "webpack --config webpack.plugin.config.js",
         "build-preview": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-preview; else echo ${1} npm run package-coreplugins && npm run build-sunbird && grunt build-preview; fi' -- ",
-        "build-aar": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-app; else npm run package-coreplugins && npm run build-sunbird && grunt build-app; fi' -- "
+        "build-aar": "bash -c 'grunt build-telemetry-lib && if [[ ${1} == \"ekstep\" ]]; then npm run package-coreplugins && npm run build-ekstep && grunt build-app; else npm run package-coreplugins && npm run build-sunbird && grunt build-app; fi' -- ",
+        "build-npm-package": "node_modules/.bin/rimraf ./www && npm run build-preview sunbird && node_modules/.bin/cpy package.json ./www/preview && node_modules/.bin/cpy ../README.md ./www/preview"
+
     },
     "cordovaPlugins": [
         "cordova-plugin-device",
@@ -100,5 +104,20 @@
         "org.apache.cordova.file",
         "cordova-plugin-file"
     ],
-    "cordovaPlatforms": []
+    "keywords": [
+        "content-player",
+        "content player",
+        "sunbird content player",
+        "genie canvas",
+        "content renderer",
+        "content-renderer",
+        "sunbird",
+        "project-sunbird"
+    ],
+    "author": "Manjunath Davanam <manjunathd@ilimi.in>",
+    "license": "MIT",
+    "bugs": {
+        "url": "https://github.com/project-sunbird/sunbird-content-player"
+    },
+    "homepage": "https://github.com/project-sunbird/sunbird-content-player#readme"
 }


### PR DESCRIPTION
@vinukumar-vs  @pallakartheekreddy 

This PR is related to build  player as npm package

Link: https://www.npmjs.com/package/@project-sunbird/content-player

Just developer as to run single command to build an content player as npm `npm run build-npm-package` // Default it will build the sunbird content player


