### PR TITLE
Issue #SB-7213 fix: Richtext WYSIWYG

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -110,7 +110,8 @@
         "AppErrors": true,
         "telemetry_web": true,
         "appConfig": true,
-        "telemetry_web": true
+        "telemetry_web": true,
+        "MobileAccessibility": true
     },
     "rules": {
         "indent": [2, "tab"],

--- a/player/Gruntfile.js
+++ b/player/Gruntfile.js
@@ -486,7 +486,8 @@ module.exports = function(grunt) {
                         'cordova-plugin-inappbrowser@1.6.1',
                         'cordova-plugin-market@1.1',
                         'https://github.com/cranberrygame/cordova-plugin-navigationbar.git',
-                        'https://github.com/apache/cordova-plugin-statusbar.git'
+                        'https://github.com/apache/cordova-plugin-statusbar.git',
+                        'https://github.com/phonegap/phonegap-mobile-accessibility.git'
                     ]
                 }
             },

--- a/player/public/js/app.js
+++ b/player/public/js/app.js
@@ -60,6 +60,7 @@ var app = angular.module("genie-canvas", ["ionic", "ngCordova", "oc.lazyLoad"])
 				if (window.cordova && window.cordova.plugins.Keyboard) {
 					cordova.plugins.Keyboard.hideKeyboardAccessoryBar(true)
 					StatusBar.hide()
+					MobileAccessibility.usePreferredTextZoom(false);
 					window.navigationbar.setUp(true)
 					navigationbar.hideNavigationBar()
 				} else {

--- a/player/public/js/basePlugin.js
+++ b/player/public/js/basePlugin.js
@@ -46,7 +46,7 @@ var Plugin = Class.extend({
     borderShape: undefined,
     _pluginParams: {},
     _manifest: {},
-    _unSupportedFonts: ["notosans", "verdana", "notosans oriya"],
+    _unSupportedFonts: ["verdana", "notosans oriya"],
     /**
      * Initializes the plugin with the given data and parent object
      * @param data {object} Init parameters for the plugin

--- a/player/public/js/basePlugin.js
+++ b/player/public/js/basePlugin.js
@@ -46,7 +46,7 @@ var Plugin = Class.extend({
     borderShape: undefined,
     _pluginParams: {},
     _manifest: {},
-    _unSupportedFonts: ["verdana", "notosans oriya"],
+    _unSupportedFonts: ["notosans", "verdana", "notosans oriya"],
     /**
      * Initializes the plugin with the given data and parent object
      * @param data {object} Init parameters for the plugin

--- a/player/public/js/splashScreen.js
+++ b/player/public/js/splashScreen.js
@@ -15,7 +15,7 @@ var splashScreen = {
 		// add event listener for hide and show of splash splashScreen
 		var instance = this
 		var elem = document.getElementById("splashScreen")
-		if (elem !== null || elem !== undefined) {
+		if (elem) {
 			elem.onclick = function () {
 				instance.launchPortal()
 			}

--- a/player/public/styles/style.css
+++ b/player/public/styles/style.css
@@ -1862,6 +1862,34 @@ body {
     line-height: 1.3 !important;
 }
 
+.richText p {
+    margin: 0 0 !important;
+}
+
+.richText h1 {
+    min-height: 1rem;
+    font-size: 2rem;
+}
+
+.richText h2 {
+    font-size: 1.71428571rem;
+}
+
+.richText h3 {
+    font-size: 1.28571429rem;
+}
+
+.richText h4 {
+    font-size: 1.07142857rem;
+}
+
+.richText h5 {
+    font-size: 1rem;
+}
+
+.richText h6 {
+    font-size: 0.67em;
+}
 
 /* new popup style */
 


### PR DESCRIPTION
Added plugin ''phonegap-mobile-accessibility" to set text zoom level to 100% on all device.
Added seperate css for richtext

For text zoom level
- Have checked with "target-densitydpi=medium-dpi" but it is deprecated
Reference - http://www.petelepage.com/blog/2013/02/viewport-target-densitydpi-support-is-being-deprecated/
- Checked with "initial-scale=1.0, maximum-scale=1.0" but this is only setting zoom level for webview not text.

Please merge Below PR also with this PR as all are related to richtext else richtext functionality will break
https://github.com/project-sunbird/sunbird-content-plugins/pull/41
https://github.com/project-sunbird/sunbird-content-editor/pull/15

**Test Content:**
Richtext New - https://ekstep-public-dev.s3-ap-south-1.amazonaws.com/ecar_files/do_1125903380079001601158/rich-text-old_1538583235448_do_1125903380079001601158_1.0.ecar

Richtext Old - https://ekstep-public-dev.s3-ap-south-1.amazonaws.com/content/do_11253525264863232015/artifact/1537783008565_do_11253525264863232015.zip