### PR TITLE
Issue SB-6830, fix: Formatting on CKEditor is not displayed on Preview

### DIFF
--- a/player/public/coreplugins/org.sunbird.player.endpage-1.1/renderer/templates/style.css
+++ b/player/public/coreplugins/org.sunbird.player.endpage-1.1/renderer/templates/style.css
@@ -1,26 +1,3 @@
-
-
-html, body, div, span, applet, object, iframe,
-h1, h2, h3, h4, h5, h6, p, blockquote, pre,
-a, abbr, acronym, address, big, cite, code,
-del, dfn, em, img, ins, kbd, q, s, samp,
-small, strike, strong, sub, sup, tt, var,
-b, u, i, center,
-dl, dt, dd, ol, ul, li,
-fieldset, form, label, legend,
-table, caption, tbody, tfoot, thead, tr, th, td,
-article, aside, canvas, details, embed,
-figure, figcaption, footer, header, hgroup,
-menu, nav, output, ruby, section, summary,
-time, mark, audio, video {
-  margin: 0;
-  padding: 0;
-  border: 0;
-  font-size: 100%;
-  font: inherit;
-  vertical-align: baseline;
-}
-
 /* HTML5 display-role reset for older browsers */
 article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {


### PR DESCRIPTION
The elements such `<strong>`, `<b>` or `<i>` are not effective on the player side, as the style.css of the endpage plugin had a reset CSS block which had reset all the styles for these tags. Hence, none of these tags which are part of the questions or options don't show as bold or italic on the preview.
This fix is to remove the reset block which dealt with such tags. Such reset block is already included in one of player's CSS files, and hence these blocks are not required to (rather should not) to be added in any plugins.