### PR TITLE
Issue #SB-9333 fix:add space between class in sunbird mobile user

### DIFF
--- a/player/public/coreplugins/org.sunbird.player.userswitcher-1.0/renderer/controller/sunbirdUserSwitcher.js
+++ b/player/public/coreplugins/org.sunbird.player.userswitcher-1.0/renderer/controller/sunbirdUserSwitcher.js
@@ -41,6 +41,9 @@ app.controllerProvider.register('SunbirdUserSwitchController', ['$scope','$rootS
 
         $scope.getUsersList = function() {
             org.ekstep.service.content.getAllUserProfile($scope.appContext).then(function(usersData) {
+                _.forEach(usersData, function(user) {
+                    user.grade = Object.values(user.gradeValueMap).toString();
+                });
                 $rootScope.users = usersData;
                 if ($rootScope.users.length == 0)
                     $rootScope.users.push($rootScope.currentUser);


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-9333

**Description:**
Mobile app : User is not able to see the spacing between the "Class" and "Class number" in user switch page.