### PR TITLE
Issue #SB-9333 fix:Space between classs and class number

### DIFF
--- a/player/public/coreplugins/org.sunbird.player.userswitcher-1.0/renderer/templates/sunbird-user-switch-popup.html
+++ b/player/public/coreplugins/org.sunbird.player.userswitcher-1.0/renderer/templates/sunbird-user-switch-popup.html
@@ -177,7 +177,7 @@ img.user-check{
                     <div class="userswitcher-data">
                         <div class="inline-username-block">
                             <p class="userswitcher-name">{{user.handle}}</p>
-                            <p ng-show="user.grade" class="userswitcher-class">{{user.grade.toString()}}</p>
+                            <span ng-show="user.grade" class="userswitcher-class" ng-repeat="(key, value) in user.gradeValueMap">{{value}}{{$last? ' ': ', '}}</span>
                         </div>
                         <div class="inline-block">
                             <img ng-show="user.selected" class="user-check" ng-src="{{checkMarkIcon}}">


### PR DESCRIPTION
**Ref:** https://project-sunbird.atlassian.net/browse/SB-9333

**Description:**
Mobile app : User is not able to see the spacing between the "Class" and "Class number" in user switch page