### PR TITLE
Issue #SB-10833 fix: Library: Broken images are displayed when user selects "Play Online" and trying to consume the resources

### DIFF
--- a/player/public/coreplugins/org.ekstep.ecmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.ecmlrenderer-1.0/renderer/plugin.js
@@ -340,6 +340,7 @@ var qspatch = {
         this.setPluginUrl(pluginInst, "iconUrl");
     },
     setPluginUrl: function(pluginObj, urlType){
+        var instance = this;
         if(!pluginObj) {
             return;
         }
@@ -348,15 +349,15 @@ var qspatch = {
             case "AssetUrl":
                 pluginObj.prototype.getAssetUrl = function (url) {
                     if (isbrowserpreview) {
-                        return url;
+                        return instance.validateUrl(url);
                     } else {
                         if (EkstepRendererAPI.isStreamingContent()) {
                             // mobile online streaming
                             if(url)
-                            return EkstepRendererAPI.getBaseURL() + url.substring(1, url.length);
+                            return instance.validateUrl(EkstepRendererAPI.getBaseURL() + url.substring(1, url.length));
                         } else {
                             // Loading content from mobile storage ( OFFLINE )
-                            return 'file:///' + EkstepRendererAPI.getBaseURL() + url;
+                            return instance.validateUrl('file:///' + EkstepRendererAPI.getBaseURL() + url);
                         }
                     }
                 }
@@ -365,16 +366,16 @@ var qspatch = {
             case "AudioUrl":
                 pluginObj.prototype.getIcon = function (path, pluginId, pluginVer) {
                     if (isbrowserpreview) {
-                        return this.getAssetUrl(org.ekstep.pluginframework.pluginManager.resolvePluginResource(pluginId, pluginVer, path));
+                        return instance.validateUrl(this.getAssetUrl(org.ekstep.pluginframework.pluginManager.resolvePluginResource(pluginId, pluginVer, path)));
                     } else {
                         if (EkstepRendererAPI.isStreamingContent()) {
                             // mobile online streaming
                             if(path)
-                            return EkstepRendererAPI.getBaseURL() + 'content-plugins/' + pluginId + '-' + pluginVer + '/' +path;
+                            return instance.validateUrl(EkstepRendererAPI.getBaseURL() + 'content-plugins/' + pluginId + '-' + pluginVer + '/' +path);
                             //return org.ekstep.pluginframework.pluginManager.resolvePluginResource(pluginId, pluginVer, path);
                         } else {
                             // Loading content from mobile storage ( OFFLINE )
-                            return 'file:///' + EkstepRendererAPI.getBaseURL() + 'content-plugins/' + pluginId + '-' + pluginVer + '/' + path;
+                            return instance.validateUrl('file:///' + EkstepRendererAPI.getBaseURL() + 'content-plugins/' + pluginId + '-' + pluginVer + '/' + path);
                         }
                     }
                 }  
@@ -383,16 +384,16 @@ var qspatch = {
             case "iconUrl":
                 pluginObj.prototype.getAudioIcon = function (path) {
                     if (isbrowserpreview) {
-                        return this.getAssetUrl(org.ekstep.pluginframework.pluginManager.resolvePluginResource(this._manifest.id, this._manifest.ver, path));
+                        return instance.validateUrl(this.getAssetUrl(org.ekstep.pluginframework.pluginManager.resolvePluginResource(this._manifest.id, this._manifest.ver, path)));
                     } else {
                         if (EkstepRendererAPI.isStreamingContent()) {
                             // mobile online streaming
                             if(path)
-                            return EkstepRendererAPI.getBaseURL() + 'content-plugins/' + this._manifest.id + '-' + this._manifest.ver + '/' + path;
+                            return instance.validateUrl(EkstepRendererAPI.getBaseURL() + 'content-plugins/' + this._manifest.id + '-' + this._manifest.ver + '/' + path);
                             //return org.ekstep.pluginframework.pluginManager.resolvePluginResource(this._manifest.id, this._manifest.ver, path);
                         } else {
                             // Loading content from mobile storage ( OFFLINE )
-                            return 'file:///' + EkstepRendererAPI.getBaseURL() + 'content-plugins/' + this._manifest.id + '-' + this._manifest.ver + '/' + path;
+                            return instance.validateUrl('file:///' + EkstepRendererAPI.getBaseURL() + 'content-plugins/' + this._manifest.id + '-' + this._manifest.ver + '/' + path);
                         }
                     }
                 }
@@ -402,6 +403,14 @@ var qspatch = {
                 break;
         }
         
+    },
+    validateUrl: function(url){
+        var regex = new RegExp("^(http|https)://", "i");
+        if(regex.test(url)){
+             return url.replace(/(https?:\/\/)|(\/)+/g, "$1$2");
+        }else{
+            return url.replace(/(file?:\/\/\/)|(\/)+/g, "$1$2");
+        } 
     }
 }
 


### PR DESCRIPTION
Issue #SB-10833 fix: Library: Broken images are displayed when user selects "Play Online" and trying to consume the resources

Issue link:- https://project-sunbird.atlassian.net/browse/SB-10833

functional scenarios :- 3