### PR TITLE
Issue #SB-10986 fix: telemetry issue for assessments

### DIFF
--- a/js-libs/renderer/manager/OverlayManager.js
+++ b/js-libs/renderer/manager/OverlayManager.js
@@ -342,6 +342,7 @@ OverlayManager = {
         };
         navType = (navType === "skip") ? "next" : navType;
         action.transitionType = navType;
+        window.PLAYER_STAGE_START_TIME = Date.now();
         CommandManager.handle(action);
     },
 


### PR DESCRIPTION
Issue #SB-10986 fix: If User click on Next button, we need to capture telemetry for, Total duration from INTERACT to IMPRESSION event in seconds and also we need to capture the loading percentage for assessment type content.