### PR TITLE
Issue #SB-12355 fix: Course Progress bar is getting updated when user closes the content while it is loading.

### DIFF
--- a/player/public/js/baseLauncher.js
+++ b/player/public/js/baseLauncher.js
@@ -98,7 +98,7 @@ org.ekstep.contentrenderer.baseLauncher = Class.extend({
      */
 	progres: function (currentIndex, totalIndex) {
 		var totalProgress = (currentIndex / totalIndex) * 100
-		totalProgress = _.isFinite(totalProgress) ? totalProgress : 0
+		totalProgress = _.isFinite(totalProgress) ? totalProgress : 1
 		totalProgress = totalProgress > 100 ? 100 : Math.round(totalProgress)
 		return totalProgress
 	},


### PR DESCRIPTION
Issue #SB-12355 fix: Course Progress bar is getting updated when user closes the content while it is loading.