### PR TITLE
Issue #SB-12938 fix:Disable left previous button when mouse click on first slide.

### DIFF
--- a/player/public/styles/style.css
+++ b/player/public/styles/style.css
@@ -481,6 +481,7 @@ ion-popover-view.fit ion-content {
 
 .nav-disable {
     opacity: 0.4;
+    pointer-events: none;
 }
 
 .overlay-html>assess {


### PR DESCRIPTION
**Ref:**https://project-sunbird.atlassian.net/browse/SB-12938

**Description:**
Pressing the 'LEFT' icon on the first slide should not shows the exit confirmation popup and any error message. Button should not be clickable on first slide previous button.