### PR TITLE
Issue #SB-15299 fix: Two loader icons are getting displayed when users trying to consume video contents

### DIFF
--- a/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
@@ -217,6 +217,11 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             EkstepRendererAPI.getTelemetryService().navigate(stageid, stageid, {
                 "duration": (Date.now() / 1000) - window.PLAYER_STAGE_START_TIME
             });
+            $('.vjs-loading-spinner').css({"top": "46%","left": "49%",
+            "width": "72px",
+            "height": "70px",
+            "border-radius": "70px",
+            "border": "5px solid rgba(47, 51, 63, 0.7)"});
         }
         var instance = this;
         instance.heartBeatEvent(true);


### PR DESCRIPTION
Issue #SB-15299 fix: Two loader icons are getting displayed when users trying to consume video contents