### PR TITLE
Issue #SB-15299 fix: Two loader icons are getting displayed when user  is trying to consume video contents

### DIFF
--- a/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
@@ -196,6 +196,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 src: path
             });
             youtubeInstance.play();
+            $('.vjs-loading-spinner').css({"display": "none"});
             instance.addYOUTUBEListeners(youtubeInstance);
             instance.setYoutubeStyles(youtubeInstance);
             instance.videoPlayer = youtubeInstance;


### PR DESCRIPTION
Issue #SB-15299 fix: Two loader icons are getting displayed when user  is trying to consume video contents