### PR TITLE
Issue #SB-15299 fix: Two loader icons are getting displayed when user is trying to consume video contents

### DIFF
--- a/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.videorenderer-1.1/renderer/plugin.js
@@ -132,6 +132,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         instance.addVideoListeners(videoPlayer, path, data);
         instance.videoPlayer = videoPlayer;
         instance.applyResolutionSwitcher();
+        $('.vjs-loading-spinner').css({"display": "none"});
     },
     applyResolutionSwitcher: function (){
         var instance = this;


### PR DESCRIPTION
Issue #SB-15299 fix: Two loader icons are getting displayed when the user is trying to consume video contents