### PR TITLE
Issue #SB-15934 fix: Post download user is blocked and unable to play the previous and next content in the course when user is trying to consume the contents

### DIFF
--- a/player/public/coreplugins/org.sunbird.player.endpage-1.1/renderer/endpageApp.js
+++ b/player/public/coreplugins/org.sunbird.player.endpage-1.1/renderer/endpageApp.js
@@ -166,6 +166,10 @@ endPage.controller("endPageController", function($scope, $rootScope, $state,$ele
             contentMetadata.basepath = contentMetadata.basePath;
             $rootScope.content = window.content = content = contentMetadata;
         }
+        
+        if(content.mimeType === "video/x-youtube"){
+            contentToPlay.content.isAvailableLocally = false;
+        }
 
         if (contentToPlay.content.isAvailableLocally) {
                 EkstepRendererAPI.hideEndPage();


### PR DESCRIPTION
Issue #SB-15934 fix: Post download user is blocked and unable to play the previous and next content in the course when user is trying to consume the contents