### PR TITLE
Issue #SB-20437 fix: PDF page navigation buttons goes off when switched resources

### DIFF
--- a/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.pdfrenderer-1.0/renderer/plugin.js
@@ -68,6 +68,12 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         $('#pdf-buttons').css({
             display: 'none'
         });
+        setTimeout(function() {
+            jQuery('previous-navigation').show();
+            jQuery('next-navigation').show();
+            jQuery('custom-previous-navigation').hide();
+            jQuery('custom-next-navigation').hide();
+        }, 100);
     },
     start: function() {
         this._super();


### PR DESCRIPTION
Issue #SB-20437 fix: PDF page navigation buttons goes off when switched resources