### PR TITLE
fix: SCORM completion event

### DIFF
--- a/player/package.json
+++ b/player/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/content-player",
-    "version": "8.0.0",
+    "version": "8.0.1",
     "description": "Which renders the contents in both web and devices",
     "dependencies": {
         "@project-sunbird/telemetry-sdk": "^0.0.14",

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -122,18 +122,19 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                 }
                 if (k === 'cmi.core.lesson_status') {
-                        var score = instance.allScoStates[instance.activeScoId]['cmi.core.score.raw'];
-                           instance.fireTelemetry('INTERACT', {
-                                type: 'OTHER',
-                                subtype: 'SCORM_PROGRESS',
-                                id: 'scorm_progress',
-                                status: v,
-                                scoId: instance.activeScoId
-                            });
-                        if (v === 'completed' || v === 'passed' || v === 'failed') {
-                            EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                        }  
+                    instance.fireTelemetry('INTERACT', {
+                        type: 'OTHER',
+                        subtype: 'SCORM_PROGRESS',
+                        id: 'scorm_progress',
+                        status: v,
+                        scoId: instance.activeScoId
+                    });
+                    var overallStatus = instance.computeOverallStatus();
+                    if (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed') {
+                        console.info("SCORM: Course completion detected via status change to", v);
+                        EkstepRendererAPI.dispatchEvent('renderer:content:end');
                     }
+                }
                 if (k === 'cmi.core.exit') {
                     instance.fireTelemetry('INTERACT', {
                         type: 'OTHER',

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -122,14 +122,18 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                 }
                 if (k === 'cmi.core.lesson_status') {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_STATUS_CHANGE',
-                        id: 'scorm_status_change',
-                        status: v
-                    });
-                }
-
+                        var score = instance.allScoStates[instance.activeScoId]['cmi.core.score.raw'];
+                           instance.fireTelemetry('INTERACT', {
+                                type: 'OTHER',
+                                subtype: 'SCORM_PROGRESS',
+                                id: 'scorm_progress',
+                                status: v,
+                                scoId: instance.activeScoId
+                            });
+                        if (v === 'completed' || v === 'passed' || v === 'failed') {
+                            EkstepRendererAPI.dispatchEvent('renderer:content:end');
+                        }  
+                    }
                 if (k === 'cmi.core.exit') {
                     instance.fireTelemetry('INTERACT', {
                         type: 'OTHER',


### PR DESCRIPTION
Summary
This PR refactors the SCORM 1.2 renderer to improve reliability and fix issues with content completion signals not firing.
Key Changes
- plugin.js Improvements:
    - Fix: Updated LMSSetValue to dispatch renderer:content:end when status becomes completed, passed, or failed. This ensures the player end-screen fires reliably even for single-SCO content that does not explicitly call LMSFinish.
    - Fix: Added default 'not attempted' status for cmi.core.lesson_status to prevent validation errors.