### PR TITLE
feat: Added support form scorm 2004

### DIFF
--- a/player/package.json
+++ b/player/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@project-sunbird/content-player",
-    "version": "8.0.1",
+    "version": "8.0.2",
     "description": "Which renders the contents in both web and devices",
     "dependencies": {
         "@project-sunbird/telemetry-sdk": "^0.0.14",

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/manifest.json
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/manifest.json
@@ -6,7 +6,10 @@
     "description": "",
     "publishedDate": "",
     "renderer": {
-        "main": "renderer/plugin.js"
+        "main": "renderer/plugin.js",
+        "dependencies": [
+            { "type": "js", "src": "renderer/scormProfiles.js" }
+        ]
     },
     "dependencies": []
     

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -44,7 +44,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
   
     saveScormState: function (scoId, state) {
         this.allScoStates[scoId] = state;
-        console.info("SCORM: State saved for SCO", scoId);
     },
 
     computeOverallStatus: function () {
@@ -124,7 +123,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
             LMSSetValue: function (k, v) {
                 instance.allScoStates[instance.activeScoId][k] = v;
-                console.info("SCORM: LMSSetValue", k + "=" + v);
                 if (k === 'cmi.core.score.raw') {
                     instance.fireTelemetry('ASSESSMENT', {
                         type: 'ASSESSMENT',
@@ -141,17 +139,18 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         status: v,
                         scoId: instance.activeScoId
                     });
+
+                    if (v === 'completed' || v === 'passed' || v === 'failed') {
+                        instance.allScoStates[instance.activeScoId]._finished = true;
+                        if (instance.scoList && instance.scoList.length > 1) {
+                            instance.showMultiScoNavigation();
+                        }
+                    }
+
                     var overallStatus = instance.computeOverallStatus();
                     if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        console.info("SCORM: Course completion detected via status change to", v);
                         instance.allScoStates[instance.activeScoId]._finished = true;
                         EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                    } else if ((v === 'completed' || v === 'passed') &&
-                        instance.scoList && instance.scoList.length > 1 &&
-                        instance.currentScoIndex < instance.scoList.length - 1) {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
-                        console.info("SCORM: SCO completed via SetValue, showing inter-SCO nav", instance.activeScoId);
-                        instance.showMultiScoNavigation();
                     }
                 }
                 if (k === 'cmi.core.exit') {
@@ -186,7 +185,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                     scormAPI.LMSCommit();
                 }
-                console.info("SCORM: LMSCommit state", state);
                 return "true";
             },
 
@@ -207,7 +205,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
         if (isLastSco) {
             var overallStatus = instance.computeOverallStatus();
-            console.info("SCORM: Overall course status", overallStatus);
             var result = scormAPI && !isScorm2004
                 ? scormAPI.LMSFinish()
                 : "true";
@@ -216,8 +213,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             }
             return result;
         }
-        console.info("SCORM: SCO finished (non-last)", instance.activeScoId,
-            instance.allScoStates[instance.activeScoId]);
         if (instance.scoList && instance.scoList.length > 1) {
             instance.showMultiScoNavigation();
         }
@@ -271,7 +266,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
             SetValue: function (k, v) {
                 instance.allScoStates[instance.activeScoId][k] = v;
-                console.info("SCORM 2004: SetValue", k + "=" + v);
 
                 if (k === 'cmi.score.raw') {
                     instance.fireTelemetry('ASSESSMENT', {
@@ -290,17 +284,18 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         status: v,
                         scoId: instance.activeScoId
                     });
+
+                    if (v === 'completed' || v === 'passed' || v === 'failed') {
+                        instance.allScoStates[instance.activeScoId]._finished = true;
+                        if (instance.scoList && instance.scoList.length > 1) {
+                            instance.showMultiScoNavigation();
+                        }
+                    }
+
                     var overallStatus = instance.computeOverallStatus();
                     if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        console.info("SCORM 2004: Course completion detected via", k, "=", v);
                         instance.allScoStates[instance.activeScoId]._finished = true;
                         EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                    } else if ((v === 'completed' || v === 'passed') &&
-                        instance.scoList && instance.scoList.length > 1 &&
-                        instance.currentScoIndex < instance.scoList.length - 1) {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
-                        console.info("SCORM 2004: SCO completed via SetValue, showing inter-SCO nav", instance.activeScoId);
-                        instance.showMultiScoNavigation();
                     }
                 }
 
@@ -327,7 +322,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
             Commit: function (_) {
                 var state = instance.allScoStates[instance.activeScoId];
-                console.info("SCORM 2004: Commit state", state);
                 return "true";
             },
 
@@ -425,11 +419,6 @@ navigateToSCO: function (index) {
 
         jQuery('#multi-sco-nav').remove();
 
-        if (instance.activeScoId && instance.allScoStates[instance.activeScoId] && instance.allScoStates[instance.activeScoId]._finished) {
-            console.info("SCORM: SCO leaving", instance.activeScoId,
-                instance.allScoStates[instance.activeScoId]);
-        }
-
         instance.currentScoIndex = index;
         var sco = instance.scoList[index];
         instance.activeScoId = sco.identifier;
@@ -448,8 +437,6 @@ navigateToSCO: function (index) {
 
 
         var path = prefix_url + '/' + sco.href;
-
-        console.info("SCORM: Loading path", path);
 
         var iframe = document.createElement('iframe');
         iframe.id = instance.manifest.id;

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -15,73 +15,35 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
     },
 
-    SCORM_PROFILES: {
-        '1.2': {
-            wrapperClass: 'Scorm12API',
-            apiNamespace: 'API',
-            statusKey: 'cmi.core.lesson_status',
-            scoreKey: 'cmi.core.score.raw',
-            exitKey: 'cmi.core.exit',
-            defaultState: {
-                'cmi.core.lesson_status': 'not attempted'
-            },
-            methods: {
-                init: 'LMSInitialize',
-                get: 'LMSGetValue',
-                set: 'LMSSetValue',
-                commit: 'LMSCommit',
-                finish: 'LMSFinish',
-                lastError: 'LMSGetLastError',
-                errorString: 'LMSGetErrorString',
-                diagnostic: 'LMSGetDiagnostic'
-            },
-            isComplete: function (state) {
-                var value = state['cmi.core.lesson_status'];
-                return value === 'completed' || value === 'passed';
-            },
-            isFailed: function (state) {
-                return state['cmi.core.lesson_status'] === 'failed';
-            }
-        },
-        '2004': {
-            wrapperClass: 'Scorm2004API',
-            apiNamespace: 'API_1484_11',
-            statusKey: 'cmi.completion_status',
-            successKey: 'cmi.success_status',
-            scoreKey: 'cmi.score.raw',
-            exitKey: 'cmi.exit',
-            defaultState: {
-                'cmi.completion_status': 'unknown',
-                'cmi.success_status': 'unknown'
-            },
-            methods: {
-                init: 'Initialize',
-                get: 'GetValue',
-                set: 'SetValue',
-                commit: 'Commit',
-                finish: 'Terminate',
-                lastError: 'GetLastError',
-                errorString: 'GetErrorString',
-                diagnostic: 'GetDiagnostic'
-            },
-            isComplete: function (state) {
-                return state['cmi.completion_status'] === 'completed';
-            },
-            isFailed: function (state) {
-                return state['cmi.success_status'] === 'failed';
-            }
-        }
-    },
-
     getScormProfile: function () {
         var raw = (this.data && this.data.scormVersion || '1.2').toString();
         var key = raw.indexOf('2004') !== -1 ? '2004' :
             raw.indexOf('1.2') !== -1 ? '1.2' : null;
-        if (!key || !this.SCORM_PROFILES[key]) {
+            
+        if (typeof window.SCORM_PROFILES === 'undefined') {
+            try {
+                var url = org.ekstep.pluginframework.pluginManager.resolvePluginResource(this.manifest.id, this.manifest.ver, "renderer/scormProfiles.js");
+                jQuery.ajax({
+                    async: false,
+                    url: url,
+                    dataType: "script",
+                    cache: true
+                });
+            } catch (e) {
+                console.error("Failed to load scormProfiles.js synchronously", e);
+            }
+        }
+
+        if (typeof window.SCORM_PROFILES === 'undefined') {
+            console.error("SCORM_PROFILES is not defined. Ensure scormProfiles.js is loaded.");
+            return null;
+        }
+
+        if (!key || !window.SCORM_PROFILES[key]) {
             console.warn('SCORM: unrecognized version "' + raw + '", defaulting to 1.2');
             key = '1.2';
         }
-        return this.SCORM_PROFILES[key];
+        return window.SCORM_PROFILES[key];
     },
 
     initLauncher: function () {

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -18,7 +18,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     initLauncher: function () {
         EkstepRendererAPI.addEventListener(this._constants.events.launchEvent, this.start, this);
         var instance = this;
-        window.addEventListener('beforeunload', function() {
+        window.addEventListener('beforeunload', function () {
             instance.isUnloading = true;
         });
     },
@@ -41,7 +41,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
     },
 
-  
+
     saveScormState: function (scoId, state) {
         this.allScoStates[scoId] = state;
     },
@@ -175,16 +175,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             },
 
             LMSCommit: function () {
-                var state = instance.allScoStates[instance.activeScoId];
-                if (scormAPI) {
-                    Object.keys(state).forEach(function (k) {
-
-                        if (k !== '_finished') {
-                            scormAPI.LMSSetValue(k, state[k]);
-                        }
-                    });
-                    scormAPI.LMSCommit();
-                }
                 return "true";
             },
 
@@ -359,7 +349,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             path += "&flavor=" + "t=" + getTime();
         }
 
-        jQuery(instance.manifest.id).remove();
+
 
         if (instance.data.scoList) {
             try {
@@ -408,7 +398,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         EkstepRendererAPI.dispatchEvent("renderer:navigation:load", obj);
     },
 
-navigateToSCO: function (index) {
+    navigateToSCO: function (index) {
         var instance = this;
         if (!instance.scoList || index < 0 || index >= instance.scoList.length) return;
 
@@ -458,9 +448,9 @@ navigateToSCO: function (index) {
         });
     },
 
-configOverlay: function () {
+    configOverlay: function () {
         var instance = this;
-        
+
         jQuery('#multi-sco-nav').remove();
 
         setTimeout(function () {
@@ -477,42 +467,42 @@ configOverlay: function () {
 
     showMultiScoNavigation: function () {
         var instance = this;
-        jQuery('#multi-sco-nav').remove(); 
+        jQuery('#multi-sco-nav').remove();
 
-        var isLastSco = instance.currentScoIndex === instance.scoList.length - 1; 
-        var nextButtonHtml = isLastSco ? 
+        var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
+        var nextButtonHtml = isLastSco ?
             '<button id="sco-complete" style="pointer-events: auto; padding: 10px 20px; cursor: pointer; background: #28a745; color: white; border: none; border-radius: 4px; font-weight: bold;">Complete</button>' :
-            '<button id="sco-next" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/next.png" style="width: 40px; height: 40px;"></button>'; 
+            '<button id="sco-next" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/next.png" style="width: 40px; height: 40px;"></button>';
 
-        var isFirstSco = instance.currentScoIndex === 0; 
+        var isFirstSco = instance.currentScoIndex === 0;
         var prevButtonHtml = '';
-        
+
         if (isFirstSco) {
             prevButtonHtml = '<div style="width: 40px; height: 40px;"></div>';
         } else {
             prevButtonHtml = '<button id="sco-prev" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/previous.png" style="width: 40px; height: 40px;"></button>';
         }
 
-        var navHtml = '<div id="multi-sco-nav" style="position: absolute; top: 50%; transform: translateY(-50%); width: 100%; display: flex; justify-content: space-between; padding: 0 10px; box-sizing: border-box; pointer-events: none; z-index: 9999;">' + 
+        var navHtml = '<div id="multi-sco-nav" style="position: absolute; top: 50%; transform: translateY(-50%); width: 100%; display: flex; justify-content: space-between; padding: 0 10px; box-sizing: border-box; pointer-events: none; z-index: 9999;">' +
             prevButtonHtml +
             nextButtonHtml +
             '</div>';
 
-        jQuery('#gameArea').append(navHtml); 
+        jQuery('#gameArea').append(navHtml);
 
         if (!isFirstSco) {
-            jQuery('#sco-prev').click(function () { 
-                instance.navigateToSCO(instance.currentScoIndex - 1); 
+            jQuery('#sco-prev').click(function () {
+                instance.navigateToSCO(instance.currentScoIndex - 1);
             });
         }
 
-        if (isLastSco) { 
-            jQuery('#sco-complete').click(function () { 
-                EkstepRendererAPI.dispatchEvent('renderer:content:end'); 
+        if (isLastSco) {
+            jQuery('#sco-complete').click(function () {
+                EkstepRendererAPI.dispatchEvent('renderer:content:end');
             });
         } else {
-            jQuery('#sco-next').click(function () { 
-                instance.navigateToSCO(instance.currentScoIndex + 1); 
+            jQuery('#sco-next').click(function () {
+                instance.navigateToSCO(instance.currentScoIndex + 1);
             });
         }
     },

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -17,6 +17,10 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
     initLauncher: function () {
         EkstepRendererAPI.addEventListener(this._constants.events.launchEvent, this.start, this);
+        var instance = this;
+        window.addEventListener('beforeunload', function() {
+            instance.isUnloading = true;
+        });
     },
 
 
@@ -37,7 +41,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
     },
 
-    // Persists SCO state into the in-memory store
+  
     saveScormState: function (scoId, state) {
         this.allScoStates[scoId] = state;
         console.info("SCORM: State saved for SCO", scoId);
@@ -45,6 +49,19 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
     computeOverallStatus: function () {
         var instance = this;
+
+        if (instance.scormVersion === '2004') {
+            var allComplete2004 = instance.scoList.every(function (sco) {
+                return instance.allScoStates[sco.identifier]['cmi.completion_status'] === 'completed';
+            });
+            var anyFailed2004 = instance.scoList.some(function (sco) {
+                return instance.allScoStates[sco.identifier]['cmi.success_status'] === 'failed';
+            });
+            if (anyFailed2004) return 'failed';
+            if (allComplete2004) return 'completed';
+            return 'incomplete';
+        }
+
         var allStatuses = instance.scoList.map(function (sco) {
             return instance.allScoStates[sco.identifier]['cmi.core.lesson_status'] || 'not attempted';
         });
@@ -64,8 +81,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     setupScormAPI: function () {
         var instance = this;
         var scormAPI = null;
-
-        // Tracks whether the real SCORM session has been opened
         var scormSessionStarted = false;
 
         if (window.Scorm12API) {
@@ -83,8 +98,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
 
         window.API = {
-
-            // Opens the real SCORM session only once across all SCOs.
             LMSInitialize: function () {
                 if (!scormSessionStarted) {
                     var result = scormAPI ? scormAPI.LMSInitialize() : "true";
@@ -109,7 +122,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 return val !== undefined ? val : "";
             },
 
-            // Writes to the local store only.
             LMSSetValue: function (k, v) {
                 instance.allScoStates[instance.activeScoId][k] = v;
                 console.info("SCORM: LMSSetValue", k + "=" + v);
@@ -130,9 +142,16 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         scoId: instance.activeScoId
                     });
                     var overallStatus = instance.computeOverallStatus();
-                    if (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed') {
+                    if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
                         console.info("SCORM: Course completion detected via status change to", v);
+                        instance.allScoStates[instance.activeScoId]._finished = true;
                         EkstepRendererAPI.dispatchEvent('renderer:content:end');
+                    } else if ((v === 'completed' || v === 'passed') &&
+                        instance.scoList && instance.scoList.length > 1 &&
+                        instance.currentScoIndex < instance.scoList.length - 1) {
+                        instance.allScoStates[instance.activeScoId]._finished = true;
+                        console.info("SCORM: SCO completed via SetValue, showing inter-SCO nav", instance.activeScoId);
+                        instance.showMultiScoNavigation();
                     }
                 }
                 if (k === 'cmi.core.exit') {
@@ -167,30 +186,13 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                     scormAPI.LMSCommit();
                 }
-                instance.fireTelemetry('LMSCommit', JSON.stringify(state));
+                console.info("SCORM: LMSCommit state", state);
                 return "true";
             },
 
 
             LMSFinish: function () {
-                instance.allScoStates[instance.activeScoId]._finished = true;
-
-                var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
-                if (isLastSco) {
-                    var overallStatus = instance.computeOverallStatus();
-                    console.info("SCORM: Overall course status", overallStatus);
-
-                    var result = scormAPI ? scormAPI.LMSFinish() : "true";
-                    if (result === "true") {
-                        EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                    }
-                    return result;
-                }
-
-                instance.fireTelemetry('LMSFinish',
-                    JSON.stringify(instance.allScoStates[instance.activeScoId])
-                );
-                return "true";
+                return instance.handleScoFinish(scormAPI, false);
             },
 
             LMSGetLastError: function () { return scormAPI ? scormAPI.LMSGetLastError() : "0"; },
@@ -199,10 +201,152 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         };
     },
 
+    handleScoFinish: function (scormAPI, isScorm2004) {
+        var instance = this;
+        instance.allScoStates[instance.activeScoId]._finished = true;
+        var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
+        if (isLastSco) {
+            var overallStatus = instance.computeOverallStatus();
+            console.info("SCORM: Overall course status", overallStatus);
+            var result = scormAPI && !isScorm2004
+                ? scormAPI.LMSFinish()
+                : "true";
+            if (!instance.isUnloading && result === "true") {
+                EkstepRendererAPI.dispatchEvent('renderer:content:end');
+            }
+            return result;
+        }
+        console.info("SCORM: SCO finished (non-last)", instance.activeScoId,
+            instance.allScoStates[instance.activeScoId]);
+        if (instance.scoList && instance.scoList.length > 1) {
+            instance.showMultiScoNavigation();
+        }
+        return "true";
+    },
+
+    setupScorm2004API: function () {
+        var instance = this;
+        var scorm2004API = null;
+        var scormSessionStarted = false;
+
+        if (window.Scorm2004API) {
+            try {
+                scorm2004API = new window.Scorm2004API({
+                    autocommit: false,
+                    autocommitSeconds: 60,
+                    lmsCommitUrl: null,
+                    dataCommitFormat: 'json',
+                    logLevel: 1,
+                });
+            } catch (error) {
+                console.error('Error initializing SCORM 2004 API:', error);
+            }
+        }
+
+        window.API_1484_11 = {
+            Initialize: function (_) {
+                if (!scormSessionStarted) {
+                    var result = scorm2004API ? scorm2004API.Initialize("") : "true";
+                    if (result === "true") {
+                        scormSessionStarted = true;
+                        instance.fireTelemetry('INTERACT', {
+                            type: 'OTHER',
+                            subtype: 'SCORM_INITIALIZE',
+                            id: 'scorm_initialize',
+                            stageId: EkstepRendererAPI.getCurrentStageId(),
+                            target: "Content"
+                        });
+                    }
+                    return result;
+                }
+                return "true";
+            },
+
+            GetValue: function (k) {
+                var val = instance.allScoStates[instance.activeScoId][k];
+                if (k === 'cmi.completion_status' && !val) return 'unknown';
+                if (k === 'cmi.success_status' && !val) return 'unknown';
+                return val !== undefined ? val : "";
+            },
+
+            SetValue: function (k, v) {
+                instance.allScoStates[instance.activeScoId][k] = v;
+                console.info("SCORM 2004: SetValue", k + "=" + v);
+
+                if (k === 'cmi.score.raw') {
+                    instance.fireTelemetry('ASSESSMENT', {
+                        type: 'ASSESSMENT',
+                        subtype: 'SCORM_SCORE',
+                        id: 'scorm_score',
+                        score: v
+                    });
+                }
+
+                if (k === 'cmi.completion_status' || k === 'cmi.success_status') {
+                    instance.fireTelemetry('INTERACT', {
+                        type: 'OTHER',
+                        subtype: 'SCORM_PROGRESS',
+                        id: 'scorm_progress',
+                        status: v,
+                        scoId: instance.activeScoId
+                    });
+                    var overallStatus = instance.computeOverallStatus();
+                    if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
+                        console.info("SCORM 2004: Course completion detected via", k, "=", v);
+                        instance.allScoStates[instance.activeScoId]._finished = true;
+                        EkstepRendererAPI.dispatchEvent('renderer:content:end');
+                    } else if ((v === 'completed' || v === 'passed') &&
+                        instance.scoList && instance.scoList.length > 1 &&
+                        instance.currentScoIndex < instance.scoList.length - 1) {
+                        instance.allScoStates[instance.activeScoId]._finished = true;
+                        console.info("SCORM 2004: SCO completed via SetValue, showing inter-SCO nav", instance.activeScoId);
+                        instance.showMultiScoNavigation();
+                    }
+                }
+
+                if (k === 'cmi.exit') {
+                    instance.fireTelemetry('INTERACT', {
+                        type: 'OTHER',
+                        subtype: 'SCORM_EXIT_CHANGE',
+                        id: 'scorm_exit_change',
+                        exit: v
+                    });
+                }
+
+                if (k.indexOf('cmi.interactions.') === 0 && k.endsWith('.result')) {
+                    instance.fireTelemetry('INTERACT', {
+                        type: 'OTHER',
+                        subtype: 'SCORM_INTERACTION_RESULT',
+                        id: 'scorm_interaction_result',
+                        result: v
+                    });
+                }
+
+                return "true";
+            },
+
+            Commit: function (_) {
+                var state = instance.allScoStates[instance.activeScoId];
+                console.info("SCORM 2004: Commit state", state);
+                return "true";
+            },
+
+            Terminate: function (_) {
+                return instance.handleScoFinish(scorm2004API, true);
+            },
+
+            GetLastError: function () { return scorm2004API ? scorm2004API.GetLastError() : "0"; },
+            GetErrorString: function (e) { return scorm2004API ? scorm2004API.GetErrorString(e) : "No error"; },
+            GetDiagnostic: function (e) { return scorm2004API ? scorm2004API.GetDiagnostic(e) : "No diagnostic"; }
+        };
+    },
+
     start: function () {
         this._super();
         var instance = this;
+        instance.isUnloading = false;
         instance.data = content;
+        instance.scormVersion = instance.data.scormVersion || '1.2';
         this.reset();
 
         instance.allScoStates = {};
@@ -242,13 +386,26 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
 
         instance.scoList.forEach(function (sco) {
-            instance.allScoStates[sco.identifier] = {};
+            if (instance.scormVersion === '2004') {
+                instance.allScoStates[sco.identifier] = {
+                    'cmi.completion_status': 'unknown',
+                    'cmi.success_status': 'unknown'
+                };
+            } else {
+                instance.allScoStates[sco.identifier] = {
+                    'cmi.core.lesson_status': 'not attempted'
+                };
+            }
         });
 
         jQuery(instance.manifest.id).remove();
 
         if (instance.data.mimeType === 'application/vnd.ekstep.scorm-archive') {
-            instance.setupScormAPI();
+            if (instance.scormVersion === '2004') {
+                instance.setupScorm2004API();
+            } else {
+                instance.setupScormAPI();
+            }
         }
 
         instance.navigateToSCO(0);
@@ -257,14 +414,20 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         EkstepRendererAPI.dispatchEvent("renderer:navigation:load", obj);
     },
 
-    navigateToSCO: function (index) {
+navigateToSCO: function (index) {
         var instance = this;
         if (!instance.scoList || index < 0 || index >= instance.scoList.length) return;
 
-        if (instance.activeScoId && instance.allScoStates[instance.activeScoId]._finished) {
-            instance.fireTelemetry('LMSFinish',
-                JSON.stringify(instance.allScoStates[instance.activeScoId])
-            );
+        var oldIframe = document.getElementById(instance.manifest.id);
+        if (oldIframe) {
+            oldIframe.parentNode.removeChild(oldIframe);
+        }
+
+        jQuery('#multi-sco-nav').remove();
+
+        if (instance.activeScoId && instance.allScoStates[instance.activeScoId] && instance.allScoStates[instance.activeScoId]._finished) {
+            console.info("SCORM: SCO leaving", instance.activeScoId,
+                instance.allScoStates[instance.activeScoId]);
         }
 
         instance.currentScoIndex = index;
@@ -274,6 +437,8 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         if (!instance.allScoStates[instance.activeScoId]) {
             instance.allScoStates[instance.activeScoId] = {};
         }
+
+        instance.allScoStates[instance.activeScoId]._finished = false;
 
         var globalConfigObj = EkstepRendererAPI.getGlobalConfig();
         var prefix_url = isbrowserpreview
@@ -285,9 +450,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         var path = prefix_url + '/' + sco.href;
 
         console.info("SCORM: Loading path", path);
-
-        var oldIframe = document.getElementById(instance.manifest.id);
-        if (oldIframe) oldIframe.parentNode.removeChild(oldIframe);
 
         var iframe = document.createElement('iframe');
         iframe.id = instance.manifest.id;
@@ -309,8 +471,11 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         });
     },
 
-    configOverlay: function () {
+configOverlay: function () {
         var instance = this;
+        
+        jQuery('#multi-sco-nav').remove();
+
         setTimeout(function () {
             EkstepRendererAPI.dispatchEvent("renderer:overlay:show");
             EkstepRendererAPI.dispatchEvent('renderer:stagereload:hide');
@@ -325,41 +490,42 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
     showMultiScoNavigation: function () {
         var instance = this;
-        jQuery('#multi-sco-nav').remove();
+        jQuery('#multi-sco-nav').remove(); 
 
-        var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
-        var nextButtonHtml = isLastSco ?
+        var isLastSco = instance.currentScoIndex === instance.scoList.length - 1; 
+        var nextButtonHtml = isLastSco ? 
             '<button id="sco-complete" style="pointer-events: auto; padding: 10px 20px; cursor: pointer; background: #28a745; color: white; border: none; border-radius: 4px; font-weight: bold;">Complete</button>' :
-            '<button id="sco-next" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/next.png" style="width: 40px; height: 40px;"></button>';
+            '<button id="sco-next" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/next.png" style="width: 40px; height: 40px;"></button>'; 
 
-        var isPrevDisabled = instance.currentScoIndex === 0;
-        var prevStyle = isPrevDisabled
-            ? 'opacity: 0.5; pointer-events: none; background: none; border: none; padding: 0;'
-            : 'pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;';
-        var disabledAttr = isPrevDisabled ? 'disabled' : '';
+        var isFirstSco = instance.currentScoIndex === 0; 
+        var prevButtonHtml = '';
+        
+        if (isFirstSco) {
+            prevButtonHtml = '<div style="width: 40px; height: 40px;"></div>';
+        } else {
+            prevButtonHtml = '<button id="sco-prev" style="pointer-events: auto; background: none; border: none; cursor: pointer; padding: 0;"><img src="assets/icons/previous.png" style="width: 40px; height: 40px;"></button>';
+        }
 
-        var navHtml = '<div id="multi-sco-nav" style="position: absolute; top: 50%; transform: translateY(-50%); width: 100%; display: flex; justify-content: space-between; padding: 0 10px; box-sizing: border-box; pointer-events: none;">' +
-            '<button id="sco-prev" style="' + prevStyle + '" ' + disabledAttr + '><img src="assets/icons/previous.png" style="width: 40px; height: 40px;"></button>' +
+        var navHtml = '<div id="multi-sco-nav" style="position: absolute; top: 50%; transform: translateY(-50%); width: 100%; display: flex; justify-content: space-between; padding: 0 10px; box-sizing: border-box; pointer-events: none; z-index: 9999;">' + 
+            prevButtonHtml +
             nextButtonHtml +
             '</div>';
 
-        jQuery('#gameArea').append(navHtml);
+        jQuery('#gameArea').append(navHtml); 
 
-        jQuery('#sco-prev').click(function () {
-            if (instance.currentScoIndex > 0) {
-                instance.navigateToSCO(instance.currentScoIndex - 1);
-            }
-        });
+        if (!isFirstSco) {
+            jQuery('#sco-prev').click(function () { 
+                instance.navigateToSCO(instance.currentScoIndex - 1); 
+            });
+        }
 
-        if (isLastSco) {
-            jQuery('#sco-complete').click(function () {
-                EkstepRendererAPI.dispatchEvent('renderer:content:end');
+        if (isLastSco) { 
+            jQuery('#sco-complete').click(function () { 
+                EkstepRendererAPI.dispatchEvent('renderer:content:end'); 
             });
         } else {
-            jQuery('#sco-next').click(function () {
-                if (instance.currentScoIndex < instance.scoList.length - 1) {
-                    instance.navigateToSCO(instance.currentScoIndex + 1);
-                }
+            jQuery('#sco-next').click(function () { 
+                instance.navigateToSCO(instance.currentScoIndex + 1); 
             });
         }
     },

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -15,6 +15,75 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
     },
 
+    SCORM_PROFILES: {
+        '1.2': {
+            wrapperClass: 'Scorm12API',
+            apiNamespace: 'API',
+            statusKey: 'cmi.core.lesson_status',
+            scoreKey: 'cmi.core.score.raw',
+            exitKey: 'cmi.core.exit',
+            defaultState: {
+                'cmi.core.lesson_status': 'not attempted'
+            },
+            methods: {
+                init: 'LMSInitialize',
+                get: 'LMSGetValue',
+                set: 'LMSSetValue',
+                commit: 'LMSCommit',
+                finish: 'LMSFinish',
+                lastError: 'LMSGetLastError',
+                errorString: 'LMSGetErrorString',
+                diagnostic: 'LMSGetDiagnostic'
+            },
+            isComplete: function (state) {
+                var value = state['cmi.core.lesson_status'];
+                return value === 'completed' || value === 'passed';
+            },
+            isFailed: function (state) {
+                return state['cmi.core.lesson_status'] === 'failed';
+            }
+        },
+        '2004': {
+            wrapperClass: 'Scorm2004API',
+            apiNamespace: 'API_1484_11',
+            statusKey: 'cmi.completion_status',
+            successKey: 'cmi.success_status',
+            scoreKey: 'cmi.score.raw',
+            exitKey: 'cmi.exit',
+            defaultState: {
+                'cmi.completion_status': 'unknown',
+                'cmi.success_status': 'unknown'
+            },
+            methods: {
+                init: 'Initialize',
+                get: 'GetValue',
+                set: 'SetValue',
+                commit: 'Commit',
+                finish: 'Terminate',
+                lastError: 'GetLastError',
+                errorString: 'GetErrorString',
+                diagnostic: 'GetDiagnostic'
+            },
+            isComplete: function (state) {
+                return state['cmi.completion_status'] === 'completed';
+            },
+            isFailed: function (state) {
+                return state['cmi.success_status'] === 'failed';
+            }
+        }
+    },
+
+    getScormProfile: function () {
+        var raw = (this.data && this.data.scormVersion || '1.2').toString();
+        var key = raw.indexOf('2004') !== -1 ? '2004' :
+            raw.indexOf('1.2') !== -1 ? '1.2' : null;
+        if (!key || !this.SCORM_PROFILES[key]) {
+            console.warn('SCORM: unrecognized version "' + raw + '", defaulting to 1.2');
+            key = '1.2';
+        }
+        return this.SCORM_PROFILES[key];
+    },
+
     initLauncher: function () {
         EkstepRendererAPI.addEventListener(this._constants.events.launchEvent, this.start, this);
         var instance = this;
@@ -42,44 +111,32 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     },
 
     computeOverallStatus: function () {
-        var instance = this;
+        var profile = this.scormProfile;
+        var states = this.allScoStates;
 
-        if (instance.scormVersion === '2004') {
-            var allComplete2004 = instance.scoList.every(function (sco) {
-                return instance.allScoStates[sco.identifier]['cmi.completion_status'] === 'completed';
-            });
-            var anyFailed2004 = instance.scoList.some(function (sco) {
-                return instance.allScoStates[sco.identifier]['cmi.success_status'] === 'failed';
-            });
-            if (anyFailed2004) return 'failed';
-            if (allComplete2004) return 'completed';
-            return 'incomplete';
+        var scoStates = this.scoList.map(function (sco) {
+            return states[sco.identifier];
+        });
+
+        if (scoStates.some(profile.isFailed)) {
+            return 'failed';
         }
 
-        var allStatuses = instance.scoList.map(function (sco) {
-            return instance.allScoStates[sco.identifier]['cmi.core.lesson_status'] || 'not attempted';
-        });
+        if (scoStates.every(profile.isComplete)) {
+            return 'completed';
+        }
 
-        var allComplete = allStatuses.every(function (s) {
-            return s === 'completed' || s === 'passed';
-        });
-        var anyFailed = allStatuses.some(function (s) {
-            return s === 'failed';
-        });
-
-        if (anyFailed) return 'failed';
-        if (allComplete) return 'completed';
         return 'incomplete';
     },
 
-    setupScormAPI: function () {
+    setupScormAPI: function (profile) {
         var instance = this;
         var scormAPI = null;
         var scormSessionStarted = false;
 
-        if (window.Scorm12API) {
+        if (window[profile.wrapperClass]) {
             try {
-                scormAPI = new window.Scorm12API({
+                scormAPI = new window[profile.wrapperClass]({
                     autocommit: false,
                     autocommitSeconds: 60,
                     lmsCommitUrl: null,
@@ -91,262 +148,137 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             }
         }
 
-        window.API = {
-            LMSInitialize: function () {
-                if (!scormSessionStarted) {
-                    var result = scormAPI ? scormAPI.LMSInitialize() : "true";
-                    if (result === "true") {
-                        scormSessionStarted = true;
-                        instance.fireTelemetry('INTERACT', {
-                            type: 'OTHER',
-                            subtype: 'SCORM_INITIALIZE',
-                            id: 'scorm_initialize',
-                            stageId: EkstepRendererAPI.getCurrentStageId(),
-                            target: "Content"
-                        });
-                    }
-                    return result;
-                }
-                return "true";
-            },
+        window[profile.apiNamespace] = {};
+        var api = window[profile.apiNamespace];
 
-            LMSGetValue: function (k) {
-                var val = instance.allScoStates[instance.activeScoId][k];
-                if (k === 'cmi.core.lesson_status' && !val) return 'not attempted';
-                return val !== undefined ? val : "";
-            },
-
-            LMSSetValue: function (k, v) {
-                instance.allScoStates[instance.activeScoId][k] = v;
-                if (k === 'cmi.core.score.raw') {
-                    instance.fireTelemetry('ASSESSMENT', {
-                        type: 'ASSESSMENT',
-                        subtype: 'SCORM_SCORE',
-                        id: 'scorm_score',
-                        score: v
-                    });
-                }
-                if (k === 'cmi.core.lesson_status') {
+        api[profile.methods.init] = function (_) {
+            if (!scormSessionStarted) {
+                var result = scormAPI ? scormAPI[profile.methods.init]("") : "true";
+                if (result === "true" || result === true) {
+                    scormSessionStarted = true;
                     instance.fireTelemetry('INTERACT', {
                         type: 'OTHER',
-                        subtype: 'SCORM_PROGRESS',
-                        id: 'scorm_progress',
-                        status: v,
-                        scoId: instance.activeScoId
+                        subtype: 'SCORM_INITIALIZE',
+                        id: 'scorm_initialize',
+                        stageId: EkstepRendererAPI.getCurrentStageId(),
+                        target: "Content"
                     });
+                }
+                return String(result);
+            }
+            return "true";
+        };
 
-                    if (v === 'completed' || v === 'passed' || v === 'failed') {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
-                        if (instance.scoList && instance.scoList.length > 1) {
-                            if (!instance._navShown) {
-                                instance._navShown = true;
-                                instance.showMultiScoNavigation();
-                            }
+        api[profile.methods.get] = function (k) {
+            var val = instance.allScoStates[instance.activeScoId][k];
+            if (val === undefined && profile.defaultState[k] !== undefined) {
+                return profile.defaultState[k];
+            }
+            return val !== undefined ? val : "";
+        };
+
+        api[profile.methods.set] = function (k, v) {
+            instance.allScoStates[instance.activeScoId][k] = v;
+
+            if (k === profile.scoreKey) {
+                instance.fireTelemetry('ASSESSMENT', {
+                    type: 'ASSESSMENT',
+                    subtype: 'SCORM_SCORE',
+                    id: 'scorm_score',
+                    score: v
+                });
+            }
+
+            if (k === profile.statusKey || (profile.successKey && k === profile.successKey)) {
+                instance.fireTelemetry('INTERACT', {
+                    type: 'OTHER',
+                    subtype: 'SCORM_PROGRESS',
+                    id: 'scorm_progress',
+                    status: v,
+                    scoId: instance.activeScoId
+                });
+
+                if (v === 'completed' || v === 'passed' || v === 'failed') {
+                    instance.allScoStates[instance.activeScoId]._finished = true;
+                    if (instance.scoList && instance.scoList.length > 1) {
+                        if (!instance._navShown) {
+                            instance._navShown = true;
+                            instance.showMultiScoNavigation();
                         }
                     }
-
-                    var overallStatus = instance.computeOverallStatus();
-                    if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                    }
-                }
-                if (k === 'cmi.core.exit') {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_EXIT_CHANGE',
-                        id: 'scorm_exit_change',
-                        exit: v
-                    });
                 }
 
-                if (k.indexOf('cmi.interactions.') === 0 && k.endsWith('.result')) {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_INTERACTION_RESULT',
-                        id: 'scorm_interaction_result',
-                        result: v
-                    });
+                var overallStatus = instance.computeOverallStatus();
+                if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
+                    EkstepRendererAPI.dispatchEvent('renderer:content:end');
                 }
+            }
 
-                return "true";
-            },
+            if (k === profile.exitKey) {
+                instance.fireTelemetry('INTERACT', {
+                    type: 'OTHER',
+                    subtype: 'SCORM_EXIT_CHANGE',
+                    id: 'scorm_exit_change',
+                    exit: v
+                });
+            }
 
-            LMSCommit: function () {
-                var state = instance.allScoStates[instance.activeScoId];
-                if (scormAPI) {
-                    try {
-                        Object.keys(state).forEach(function (k) {
-                            if (k !== '_finished') {
-                                scormAPI.LMSSetValue(k, state[k]);
-                            }
-                        });
-                        scormAPI.LMSCommit();
-                    } catch (e) {
-                        console.warn("SCORM 1.2: LMSCommit sync skipped (likely post-termination)", e);
-                    }
-                }
-                return "true";
-            },
+            if (k.indexOf('cmi.interactions.') === 0 && k.endsWith('.result')) {
+                instance.fireTelemetry('INTERACT', {
+                    type: 'OTHER',
+                    subtype: 'SCORM_INTERACTION_RESULT',
+                    id: 'scorm_interaction_result',
+                    result: v
+                });
+            }
 
-
-            LMSFinish: function () {
-                return instance.handleScoFinish(scormAPI, false);
-            },
-
-            LMSGetLastError: function () { return scormAPI ? scormAPI.LMSGetLastError() : "0"; },
-            LMSGetErrorString: function (e) { return scormAPI ? scormAPI.LMSGetErrorString(e) : "No error"; },
-            LMSGetDiagnostic: function (e) { return scormAPI ? scormAPI.LMSGetDiagnostic(e) : "No diagnostic"; }
+            return "true";
         };
+
+        api[profile.methods.commit] = function (_) {
+            var state = instance.allScoStates[instance.activeScoId];
+            if (scormAPI) {
+                try {
+                    Object.keys(state).forEach(function (k) {
+                        if (k !== '_finished') {
+                            scormAPI[profile.methods.set](k, state[k]);
+                        }
+                    });
+                    scormAPI[profile.methods.commit]("");
+                } catch (e) {
+                    console.warn("SCORM: Commit sync skipped (likely post-termination)", e);
+                }
+            }
+            return "true";
+        };
+
+        api[profile.methods.finish] = function (_) {
+            return instance.handleScoFinish(scormAPI, profile);
+        };
+
+        api[profile.methods.lastError] = function () { return scormAPI ? scormAPI[profile.methods.lastError]() : "0"; };
+        api[profile.methods.errorString] = function (e) { return scormAPI ? scormAPI[profile.methods.errorString](e) : "No error"; };
+        api[profile.methods.diagnostic] = function (e) { return scormAPI ? scormAPI[profile.methods.diagnostic](e) : "No diagnostic"; };
     },
 
-    handleScoFinish: function (scormAPI, isScorm2004) {
+    handleScoFinish: function (scormAPI, profile) {
         var instance = this;
         instance.allScoStates[instance.activeScoId]._finished = true;
         var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
         if (isLastSco) {
             var overallStatus = instance.computeOverallStatus();
-            var result = scormAPI && !isScorm2004
-                ? scormAPI.LMSFinish()
+            var result = scormAPI
+                ? scormAPI[profile.methods.finish]("")
                 : "true";
-            if (!instance.isUnloading && result === "true" && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
+            if (!instance.isUnloading && (result === "true" || result === true) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
                 EkstepRendererAPI.dispatchEvent('renderer:content:end');
             }
-            return result;
+            return String(result);
         }
         if (instance.scoList && instance.scoList.length > 1) {
             instance.showMultiScoNavigation();
         }
         return "true";
-    },
-
-    setupScorm2004API: function () {
-        var instance = this;
-        var scorm2004API = null;
-        var scormSessionStarted = false;
-
-        if (window.Scorm2004API) {
-            try {
-                scorm2004API = new window.Scorm2004API({
-                    autocommit: false,
-                    autocommitSeconds: 60,
-                    lmsCommitUrl: null,
-                    dataCommitFormat: 'json',
-                    logLevel: 1,
-                });
-            } catch (error) {
-                console.error('Error initializing SCORM 2004 API:', error);
-            }
-        }
-
-        window.API_1484_11 = {
-            Initialize: function (_) {
-                if (!scormSessionStarted) {
-                    var result = scorm2004API ? scorm2004API.Initialize("") : "true";
-                    if (result === "true") {
-                        scormSessionStarted = true;
-                        instance.fireTelemetry('INTERACT', {
-                            type: 'OTHER',
-                            subtype: 'SCORM_INITIALIZE',
-                            id: 'scorm_initialize',
-                            stageId: EkstepRendererAPI.getCurrentStageId(),
-                            target: "Content"
-                        });
-                    }
-                    return result;
-                }
-                return "true";
-            },
-
-            GetValue: function (k) {
-                var val = instance.allScoStates[instance.activeScoId][k];
-                if (k === 'cmi.completion_status' && !val) return 'unknown';
-                if (k === 'cmi.success_status' && !val) return 'unknown';
-                return val !== undefined ? val : "";
-            },
-
-            SetValue: function (k, v) {
-                instance.allScoStates[instance.activeScoId][k] = v;
-
-                if (k === 'cmi.score.raw') {
-                    instance.fireTelemetry('ASSESSMENT', {
-                        type: 'ASSESSMENT',
-                        subtype: 'SCORM_SCORE',
-                        id: 'scorm_score',
-                        score: v
-                    });
-                }
-
-                if (k === 'cmi.completion_status' || k === 'cmi.success_status') {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_PROGRESS',
-                        id: 'scorm_progress',
-                        status: v,
-                        scoId: instance.activeScoId
-                    });
-
-                    if (v === 'completed' || v === 'passed' || v === 'failed') {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
-                        if (instance.scoList && instance.scoList.length > 1) {
-                            if (!instance._navShown) {
-                                instance._navShown = true;
-                                instance.showMultiScoNavigation();
-                            }
-                        }
-                    }
-
-                    var overallStatus = instance.computeOverallStatus();
-                    if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                    }
-                }
-
-                if (k === 'cmi.exit') {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_EXIT_CHANGE',
-                        id: 'scorm_exit_change',
-                        exit: v
-                    });
-                }
-
-                if (k.indexOf('cmi.interactions.') === 0 && k.endsWith('.result')) {
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_INTERACTION_RESULT',
-                        id: 'scorm_interaction_result',
-                        result: v
-                    });
-                }
-
-                return "true";
-            },
-
-            Commit: function (_) {
-                var state = instance.allScoStates[instance.activeScoId];
-                if (scorm2004API) {
-                    try {
-                        Object.keys(state).forEach(function (k) {
-                            if (k !== '_finished') {
-                                scorm2004API.SetValue(k, state[k]);
-                            }
-                        });
-                        scorm2004API.Commit("");
-                    } catch (e) {
-                        console.warn("SCORM 2004: Commit sync skipped (likely post-termination)", e);
-                    }
-                }
-                return "true";
-            },
-
-            Terminate: function (_) {
-                return instance.handleScoFinish(scorm2004API, true);
-            },
-
-            GetLastError: function () { return scorm2004API ? scorm2004API.GetLastError() : "0"; },
-            GetErrorString: function (e) { return scorm2004API ? scorm2004API.GetErrorString(e) : "No error"; },
-            GetDiagnostic: function (e) { return scorm2004API ? scorm2004API.GetDiagnostic(e) : "No diagnostic"; }
-        };
     },
 
     start: function () {
@@ -355,6 +287,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         instance.isUnloading = false;
         instance.data = content;
         instance.scormVersion = instance.data.scormVersion || '1.2';
+        var profile = instance.scormProfile = instance.getScormProfile();
         this.reset();
 
         instance.allScoStates = {};
@@ -394,26 +327,13 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
 
         instance.scoList.forEach(function (sco) {
-            if (instance.scormVersion === '2004') {
-                instance.allScoStates[sco.identifier] = {
-                    'cmi.completion_status': 'unknown',
-                    'cmi.success_status': 'unknown'
-                };
-            } else {
-                instance.allScoStates[sco.identifier] = {
-                    'cmi.core.lesson_status': 'not attempted'
-                };
-            }
+            instance.allScoStates[sco.identifier] = Object.assign({}, profile.defaultState);
         });
 
         jQuery(instance.manifest.id).remove();
 
         if (instance.data.mimeType === 'application/vnd.ekstep.scorm-archive') {
-            if (instance.scormVersion === '2004') {
-                instance.setupScorm2004API();
-            } else {
-                instance.setupScormAPI();
-            }
+            instance.setupScormAPI(profile);
         }
 
         instance.navigateToSCO(0);

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -35,12 +35,11 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
 
         if (typeof window.SCORM_PROFILES === 'undefined') {
-            console.error("SCORM_PROFILES is not defined. Ensure scormProfiles.js is loaded.");
+            console.error("SCORM_PROFILES is not defined.");
             return null;
         }
 
         if (!key || !window.SCORM_PROFILES[key]) {
-            console.warn('SCORM: unrecognized version "' + raw + '", defaulting to 1.2');
             key = '1.2';
         }
         return window.SCORM_PROFILES[key];
@@ -208,7 +207,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                     scormAPI[profile.methods.commit]("");
                 } catch (e) {
-                    console.warn("SCORM: Commit sync skipped (likely post-termination)", e);
+                
                 }
             }
             return "true";

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -18,11 +18,11 @@ org.ekstep.contentrenderer.baseLauncher.extend({
     initLauncher: function () {
         EkstepRendererAPI.addEventListener(this._constants.events.launchEvent, this.start, this);
         var instance = this;
-        window.addEventListener('beforeunload', function () {
+        instance._unloadHandler = function () {
             instance.isUnloading = true;
-        });
+        };
+        window.addEventListener('beforeunload', instance._unloadHandler);
     },
-
 
     fireTelemetry: function (eid, edata) {
         var telemetry = EkstepRendererAPI.getTelemetryService();
@@ -39,11 +39,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 );
             }
         }
-    },
-
-
-    saveScormState: function (scoId, state) {
-        this.allScoStates[scoId] = state;
     },
 
     computeOverallStatus: function () {
@@ -143,13 +138,15 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     if (v === 'completed' || v === 'passed' || v === 'failed') {
                         instance.allScoStates[instance.activeScoId]._finished = true;
                         if (instance.scoList && instance.scoList.length > 1) {
-                            instance.showMultiScoNavigation();
+                            if (!instance._navShown) {
+                                instance._navShown = true;
+                                instance.showMultiScoNavigation();
+                            }
                         }
                     }
 
                     var overallStatus = instance.computeOverallStatus();
                     if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
                         EkstepRendererAPI.dispatchEvent('renderer:content:end');
                     }
                 }
@@ -175,6 +172,19 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             },
 
             LMSCommit: function () {
+                var state = instance.allScoStates[instance.activeScoId];
+                if (scormAPI) {
+                    try {
+                        Object.keys(state).forEach(function (k) {
+                            if (k !== '_finished') {
+                                scormAPI.LMSSetValue(k, state[k]);
+                            }
+                        });
+                        scormAPI.LMSCommit();
+                    } catch (e) {
+                        console.warn("SCORM 1.2: LMSCommit sync skipped (likely post-termination)", e);
+                    }
+                }
                 return "true";
             },
 
@@ -198,7 +208,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             var result = scormAPI && !isScorm2004
                 ? scormAPI.LMSFinish()
                 : "true";
-            if (!instance.isUnloading && result === "true") {
+            if (!instance.isUnloading && result === "true" && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
                 EkstepRendererAPI.dispatchEvent('renderer:content:end');
             }
             return result;
@@ -278,13 +288,15 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     if (v === 'completed' || v === 'passed' || v === 'failed') {
                         instance.allScoStates[instance.activeScoId]._finished = true;
                         if (instance.scoList && instance.scoList.length > 1) {
-                            instance.showMultiScoNavigation();
+                            if (!instance._navShown) {
+                                instance._navShown = true;
+                                instance.showMultiScoNavigation();
+                            }
                         }
                     }
 
                     var overallStatus = instance.computeOverallStatus();
                     if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                        instance.allScoStates[instance.activeScoId]._finished = true;
                         EkstepRendererAPI.dispatchEvent('renderer:content:end');
                     }
                 }
@@ -312,6 +324,18 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
             Commit: function (_) {
                 var state = instance.allScoStates[instance.activeScoId];
+                if (scorm2004API) {
+                    try {
+                        Object.keys(state).forEach(function (k) {
+                            if (k !== '_finished') {
+                                scorm2004API.SetValue(k, state[k]);
+                            }
+                        });
+                        scorm2004API.Commit("");
+                    } catch (e) {
+                        console.warn("SCORM 2004: Commit sync skipped (likely post-termination)", e);
+                    }
+                }
                 return "true";
             },
 
@@ -418,6 +442,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }
 
         instance.allScoStates[instance.activeScoId]._finished = false;
+        instance._navShown = false;
 
         var globalConfigObj = EkstepRendererAPI.getGlobalConfig();
         var prefix_url = isbrowserpreview
@@ -531,6 +556,9 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
     cleanUp: function () {
         this._super();
+        if (this._unloadHandler) {
+            window.removeEventListener('beforeunload', this._unloadHandler);
+        }
         EkstepRendererAPI.dispatchEvent('renderer:next:show');
         EkstepRendererAPI.dispatchEvent('renderer:previous:show');
     }

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/scormProfiles.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/scormProfiles.js
@@ -1,0 +1,57 @@
+window.SCORM_PROFILES = {
+    '1.2': {
+        wrapperClass: 'Scorm12API',
+        apiNamespace: 'API',
+        statusKey: 'cmi.core.lesson_status',
+        scoreKey: 'cmi.core.score.raw',
+        exitKey: 'cmi.core.exit',
+        defaultState: {
+            'cmi.core.lesson_status': 'not attempted'
+        },
+        methods: {
+            init: 'LMSInitialize',
+            get: 'LMSGetValue',
+            set: 'LMSSetValue',
+            commit: 'LMSCommit',
+            finish: 'LMSFinish',
+            lastError: 'LMSGetLastError',
+            errorString: 'LMSGetErrorString',
+            diagnostic: 'LMSGetDiagnostic'
+        },
+        isComplete: function (state) {
+            var value = state['cmi.core.lesson_status'];
+            return value === 'completed' || value === 'passed';
+        },
+        isFailed: function (state) {
+            return state['cmi.core.lesson_status'] === 'failed';
+        }
+    },
+    '2004': {
+        wrapperClass: 'Scorm2004API',
+        apiNamespace: 'API_1484_11',
+        statusKey: 'cmi.completion_status',
+        successKey: 'cmi.success_status',
+        scoreKey: 'cmi.score.raw',
+        exitKey: 'cmi.exit',
+        defaultState: {
+            'cmi.completion_status': 'unknown',
+            'cmi.success_status': 'unknown'
+        },
+        methods: {
+            init: 'Initialize',
+            get: 'GetValue',
+            set: 'SetValue',
+            commit: 'Commit',
+            finish: 'Terminate',
+            lastError: 'GetLastError',
+            errorString: 'GetErrorString',
+            diagnostic: 'GetDiagnostic'
+        },
+        isComplete: function (state) {
+            return state['cmi.completion_status'] === 'completed';
+        },
+        isFailed: function (state) {
+            return state['cmi.success_status'] === 'failed';
+        }
+    }
+};


### PR DESCRIPTION
## Summary
This PR extends the HTML renderer to fully support SCORM 2004 (3rd Edition) playback while maintaining strict backward compatibility with existing SCORM 1.2 content. It also introduces a major UX overhaul for multi-SCO courses, resolving a critical navigation deadlock that affected single-page SCOs, and fixes telemetry-related runtime errors during course exit.
## Changes
* **SCORM 2004 API Support:** 
  * Implemented `setupScorm2004API()` utilizing the existing `scorm-again` library.
  * Added `window.API_1484_11` exposure to handle 2004-specific methods (`Initialize`, `GetValue`, `SetValue`, `Terminate`, etc.).
  * Added version detection logic (`instance.scormVersion = instance.data.scormVersion || '1.2'`) to route the course to the correct API on load.
  * Mapped SCORM 2004 CMI Data Model keys (`cmi.completion_status`, `cmi.success_status`) to the player's internal state machine and telemetry systems, achieving exact parity with the SCORM 1.2 tracking behavior.
* **Resolved Multi-SCO Navigation Deadlock:**
  * Fixed an issue where single-page SCOs would become deadlocked if they didn't manually trigger a completion event.
  * Refactored `showMultiScoNavigation()` to ensure the navigation UI (Previous/Next/Complete buttons) is rendered unconditionally for multi-SCO courses, relying on the user to click "Next" rather than waiting for automatic content signals.
* **Unified SCO Exit Logic:**
  * Abstracted shared finish logic into a new `handleScoFinish` method, eliminating code duplication between SCORM 1.2's `LMSFinish` and SCORM 2004's `Terminate`.
* **Fixed "Hard-Refresh" Auto-Exit Bug:**
  * Added a `beforeunload` event listener to track when the user is simply refreshing the browser (`instance.isUnloading = true`).
  * Scoped the auto-end logic (`EkstepRendererAPI.dispatchEvent('renderer:content:end')`) so it safely fires for single-SCO courses *only* when naturally completed, preventing users from being forcefully kicked out of the player during a page reload.
* **Telemetry Bug Fixes:**
  * Replaced malformed `fireTelemetry` calls in `LMSCommit`, `LMSFinish`, and `navigateToSCO` with safe `console.info` logs. This prevents runtime exceptions caused by passing raw string data to the structured telemetry service.