### PR TITLE
fix: Scorm assesment tracking

### DIFF
--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -139,22 +139,41 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         };
 
         api[profile.methods.set] = function (k, v) {
+            var previousValue = instance.allScoStates[instance.activeScoId][k];
             instance.allScoStates[instance.activeScoId][k] = v;
 
-            if (k === profile.scoreKey && !instance._assessStartedFor[instance.activeScoId]) {
+            // Each scoreKey set is its own complete, independent ASSESS event
+            // (mirrors QUML's one-ASSESS-per-question). A SCO may set the same
+            // value multiple times (idempotent autosave-style calls) - skip those.
+            if (k === profile.scoreKey && v !== previousValue) {
                 var telemetry = EkstepRendererAPI.getTelemetryService();
                 if (telemetry) {
                     try {
-                        var maxScoreValue = instance.allScoStates[instance.activeScoId][profile.scoreMaxKey];
+                        var state = instance.allScoStates[instance.activeScoId];
+                        var maxScoreValue = state[profile.scoreMaxKey];
                         var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
-                        instance._assessStartedFor[instance.activeScoId] = telemetry.assess(
-                            instance.activeScoId,
+                        var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
+                        instance._scormAssessCounter = (instance._scormAssessCounter || 0) + 1;
+                        var qid = instance.activeScoId + '-' + instance._scormAssessCounter;
+                        var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
+                        var startEvent = telemetry.assess(
+                            qid,
                             instance.data.subject || 'SCORM',
                             'MEDIUM',
                             { maxscore: maxScore }
                         ).start();
+                        telemetry.assessEnd(startEvent, {
+                            pass: (statusValue === 'completed' || statusValue === 'passed'),
+                            score: v,
+                            qindex: instance._scormAssessCounter - 1,
+                            qtitle: activeSco ? activeSco.title : '',
+                            qdesc: '',
+                            res: [],
+                            mmc: [],
+                            mc: []
+                        });
                     } catch (e) {
-                        console.error('SCORM: Unable to start ASSESS telemetry', e);
+                        console.error('SCORM: Unable to record ASSESS telemetry', e);
                     }
 
                     instance.fireTelemetry('INTERACT', {
@@ -186,12 +205,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         }
                     }
                 }
-
-                var overallStatus = instance.computeOverallStatus();
-                if (!instance.isUnloading && (instance.scoList.length === 1) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                    EkstepRendererAPI.dispatchEvent('renderer:content:end');
-                }
-            }
+                           }
 
             if (k === profile.exitKey) {
                 instance.fireTelemetry('INTERACT', {
@@ -225,32 +239,14 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                     });
                     scormAPI[profile.methods.commit]("");
                 } catch (e) {
-
+                    console.error('SCORM: wrapper commit failed', e);
                 }
             }
 
-            if (state._finished && instance._assessStartedFor[instance.activeScoId] && !instance._assessEndedFor[instance.activeScoId]) {
-                var telemetry = EkstepRendererAPI.getTelemetryService();
-                if (telemetry) {
-                    try {
-                        var startEvent = instance._assessStartedFor[instance.activeScoId];
-                        var statusValue = state[profile.statusKey] || state[profile.successKey];
-                        var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
-                        telemetry.assessEnd(startEvent, {
-                            pass: (statusValue === 'completed' || statusValue === 'passed'),
-                            score: state[profile.scoreKey],
-                            qindex: instance.currentScoIndex,
-                            qtitle: activeSco ? activeSco.title : '',
-                            qdesc: '',
-                            res: [],
-                            mmc: [],
-                            mc: []
-                        });
-                    } catch (e) {
-                        console.error('SCORM: Unable to end ASSESS telemetry', e);
-                    }
-                    instance._assessEndedFor[instance.activeScoId] = true;
-                    delete instance._assessStartedFor[instance.activeScoId];
+            if (state._finished && instance.scoList && instance.scoList.length === 1) {
+                var overallStatus = instance.computeOverallStatus();
+                if (!instance.isUnloading && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
+                    EkstepRendererAPI.dispatchEvent('renderer:content:end');
                 }
             }
 
@@ -298,8 +294,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         instance.allScoStates = {};
         instance.scoList = [];
         instance.currentScoIndex = 0;
-        instance._assessStartedFor = {};
-        instance._assessEndedFor = {};
+        instance._scormAssessCounter = 0;
 
         var isMobile = window.cordova ? true : false;
         var envHTML = isMobile ? "app" : "portal";
@@ -370,6 +365,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
         instance.allScoStates[instance.activeScoId]._finished = false;
         instance._navShown = false;
+        instance._scormAssessCounter = 0;
 
         var globalConfigObj = EkstepRendererAPI.getGlobalConfig();
         var prefix_url = isbrowserpreview

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -144,14 +144,26 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             if (k === profile.scoreKey && !instance._assessStartedFor[instance.activeScoId]) {
                 var telemetry = EkstepRendererAPI.getTelemetryService();
                 if (telemetry) {
-                    var maxScoreValue = instance.allScoStates[instance.activeScoId][profile.scoreMaxKey];
-                    var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
-                    instance._assessStartedFor[instance.activeScoId] = telemetry.assess(
-                        instance.activeScoId,
-                        instance.data.subject || 'SCORM',
-                        'MEDIUM',
-                        { maxscore: maxScore }
-                    ).start();
+                    try {
+                        var maxScoreValue = instance.allScoStates[instance.activeScoId][profile.scoreMaxKey];
+                        var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
+                        instance._assessStartedFor[instance.activeScoId] = telemetry.assess(
+                            instance.activeScoId,
+                            instance.data.subject || 'SCORM',
+                            'MEDIUM',
+                            { maxscore: maxScore }
+                        ).start();
+                    } catch (e) {
+                        console.error('SCORM: Unable to start ASSESS telemetry', e);
+                    }
+
+                    instance.fireTelemetry('INTERACT', {
+                        type: 'OTHER',
+                        subtype: 'SCORM_PROGRESS',
+                        id: 'scorm_progress',
+                        status: 'incomplete',
+                        scoId: instance.activeScoId
+                    });
                 }
             }
 
@@ -220,19 +232,23 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             if (state._finished && instance._assessStartedFor[instance.activeScoId] && !instance._assessEndedFor[instance.activeScoId]) {
                 var telemetry = EkstepRendererAPI.getTelemetryService();
                 if (telemetry) {
-                    var startEvent = instance._assessStartedFor[instance.activeScoId];
-                    var statusValue = state[profile.statusKey] || state[profile.successKey];
-                    var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
-                    telemetry.assessEnd(startEvent, {
-                        pass: (statusValue === 'completed' || statusValue === 'passed'),
-                        score: state[profile.scoreKey],
-                        qindex: instance.currentScoIndex,
-                        qtitle: activeSco ? activeSco.title : '',
-                        qdesc: '',
-                        res: [],
-                        mmc: [],
-                        mc: []
-                    });
+                    try {
+                        var startEvent = instance._assessStartedFor[instance.activeScoId];
+                        var statusValue = state[profile.statusKey] || state[profile.successKey];
+                        var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
+                        telemetry.assessEnd(startEvent, {
+                            pass: (statusValue === 'completed' || statusValue === 'passed'),
+                            score: state[profile.scoreKey],
+                            qindex: instance.currentScoIndex,
+                            qtitle: activeSco ? activeSco.title : '',
+                            qdesc: '',
+                            res: [],
+                            mmc: [],
+                            mc: []
+                        });
+                    } catch (e) {
+                        console.error('SCORM: Unable to end ASSESS telemetry', e);
+                    }
                     instance._assessEndedFor[instance.activeScoId] = true;
                     delete instance._assessStartedFor[instance.activeScoId];
                 }

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -216,8 +216,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         var maxScoreValue = state[profile.scoreMaxKey];
                         var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
                         var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
-                        instance._scormAssessCounter = (instance._scormAssessCounter || 0) + 1;
-                        var qid = instance.activeScoId + '-' + instance._scormAssessCounter;
+                        var qid = instance.activeScoId;
                         var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
                         var startEvent = telemetry.assess(
                             qid,
@@ -228,7 +227,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                         telemetry.assessEnd(startEvent, {
                             pass: (statusValue === 'completed' || statusValue === 'passed'),
                             score: currentScore,
-                            qindex: instance._scormAssessCounter - 1,
+                            qindex: instance.currentScoIndex,
                             qtitle: activeSco ? activeSco.title : '',
                             qdesc: '',
                             res: [],
@@ -434,6 +433,25 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         }, 100);
     },
 
+    hasAttemptedCurrentSco: function () {
+        var instance = this;
+        var profile = instance.scormProfile;
+        if (!profile) return true;
+        var state = instance.allScoStates[instance.activeScoId] || {};
+        var scoreValue = state[profile.scoreKey];
+        var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
+        var hasInteraction = Object.keys(state).some(function (k) {
+            return k.indexOf('cmi.interactions.') === 0 && k.endsWith('.result');
+        });
+        var isDefaultState = scoreValue === undefined &&
+            (!statusValue || statusValue === profile.defaultState[profile.statusKey]) &&
+            !hasInteraction;
+        if (isDefaultState) return true;
+        if (scoreValue !== undefined) return true;
+        if (statusValue && statusValue !== profile.defaultState[profile.statusKey]) return true;
+        return hasInteraction;
+    },
+
     showMultiScoNavigation: function () {
         var instance = this;
         jQuery('#multi-sco-nav').remove();
@@ -467,10 +485,16 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
         if (isLastSco) {
             jQuery('#sco-complete').click(function () {
+                if (!instance.hasAttemptedCurrentSco() && !window.confirm("You haven't attempted this section's quiz yet. Complete the course anyway?")) {
+                    return;
+                }
                 EkstepRendererAPI.dispatchEvent('renderer:content:end');
             });
         } else {
             jQuery('#sco-next').click(function () {
+                if (!instance.hasAttemptedCurrentSco() && !window.confirm("You haven't attempted this section's quiz yet. Continue to the next section anyway?")) {
+                    return;
+                }
                 instance.navigateToSCO(instance.currentScoIndex + 1);
             });
         }

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -90,6 +90,50 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         return 'incomplete';
     },
 
+    fireAggregatedAssess: function () {
+        var instance = this;
+        var profile = instance.scormProfile;
+        if (instance.maxAttemptsExceeded || instance._aggregateAssessFired) return;
+
+        var quizStates = instance.scoList
+            .map(function (sco) { return instance.allScoStates[sco.identifier]; })
+            .filter(function (state) { return state && state[profile.scoreKey] !== undefined; });
+
+        if (quizStates.length === 0) return;
+
+        var total = 0;
+        var allPassed = true;
+        quizStates.forEach(function (state) {
+            total += Number(state[profile.scoreKey]) || 0;
+            var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
+            if (!(statusValue === 'completed' || statusValue === 'passed')) allPassed = false;
+        });
+        var avgScore = total / quizStates.length;
+
+        var telemetry = EkstepRendererAPI.getTelemetryService();
+        if (!telemetry) return;
+        try {
+            var qid = instance.data.identifier || instance.activeScoId;
+            var startEvent = telemetry.assess(
+                qid,
+                instance.data.subject || 'SCORM',
+                'MEDIUM',
+                { maxscore: 100 }
+            ).start();
+            telemetry.assessEnd(startEvent, {
+                pass: allPassed,
+                score: avgScore,
+                qindex: 0,
+                qtitle: instance.data.name || '',
+                qdesc: '',
+                res: [], mmc: [], mc: []
+            });
+            instance._aggregateAssessFired = true;
+        } catch (e) {
+            console.error('SCORM: Unable to record aggregated ASSESS telemetry', e);
+        }
+    },
+
     setupScormAPI: function (profile) {
         var instance = this;
         var scormAPI = null;
@@ -131,6 +175,14 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         };
 
         api[profile.methods.get] = function (k) {
+            if (k === profile.entryKey) {
+                var state = instance.allScoStates[instance.activeScoId];
+                var hasSuspendData = state[profile.statusKey] && state[profile.statusKey] !== profile.defaultState[profile.statusKey];
+                return hasSuspendData ? 'resume' : 'ab-initio';
+            }
+            if (k === profile.modeKey) {
+                return instance.maxAttemptsExceeded ? 'review' : 'normal';
+            }
             var val = instance.allScoStates[instance.activeScoId][k];
             if (val === undefined && profile.defaultState[k] !== undefined) {
                 return profile.defaultState[k];
@@ -139,6 +191,9 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         };
 
         api[profile.methods.set] = function (k, v) {
+            if (k === profile.entryKey || k === profile.modeKey) {
+                return "true";
+            }
             instance.allScoStates[instance.activeScoId][k] = v;
 
             if (k === profile.scoreKey) {
@@ -209,7 +264,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             }
 
             var currentScore = state[profile.scoreKey];
-            if (currentScore !== undefined && currentScore !== instance._lastReportedScore[instance.activeScoId]) {
+            if (!instance.isMultiSco && !instance.maxAttemptsExceeded && currentScore !== undefined && currentScore !== instance._lastReportedScore[instance.activeScoId]) {
                 var telemetry = EkstepRendererAPI.getTelemetryService();
                 if (telemetry) {
                     try {
@@ -272,13 +327,21 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 result = scormAPI[profile.methods.finish]("");
             }
             if (isMultiSco) {
+                instance.fireAggregatedAssess();
+            }
+            if (!instance.isUnloading && (result === "true" || result === true)) {
+                var overallStatus = instance.computeOverallStatus();
+                var hasAssessment = instance.scoList.some(function (sco) {
+                    var state = instance.allScoStates[sco.identifier];
+                    return state && state[profile.scoreKey] !== undefined;
+                });
+                if (hasAssessment ? (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed') : true) {
+                    EkstepRendererAPI.dispatchEvent('renderer:content:end');
+                }
+            }
+            if (isMultiSco) {
                 instance._navShown = true;
                 instance.showMultiScoNavigation();
-                return String(result);
-            }
-            var overallStatus = instance.computeOverallStatus();
-            if (!instance.isUnloading && (result === "true" || result === true) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
-                EkstepRendererAPI.dispatchEvent('renderer:content:end');
             }
             return String(result);
         }
@@ -300,9 +363,14 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         instance.allScoStates = {};
         instance.scoList = [];
         instance.currentScoIndex = 0;
-        instance._scormAssessCounter = 0;
         instance._lastReportedScore = {};
         instance._realFinishCalled = false;
+
+        instance.maxAttempts = instance.data.maxAttempts;
+        instance.currentAttempt = instance.data.currentAttempt || 0;
+        instance.maxAttemptsExceeded = instance.maxAttempts != null && instance.currentAttempt >= instance.maxAttempts;
+        instance.isMultiSco = false;
+        instance._aggregateAssessFired = false;
 
         var isMobile = window.cordova ? true : false;
         var envHTML = isMobile ? "app" : "portal";
@@ -335,6 +403,8 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 href: instance.data.launchFile || 'index.html'
             }];
         }
+
+        instance.isMultiSco = instance.scoList && instance.scoList.length > 1;
 
         instance.scoList.forEach(function (sco) {
             instance.allScoStates[sco.identifier] = Object.assign({}, profile.defaultState);
@@ -373,7 +443,6 @@ org.ekstep.contentrenderer.baseLauncher.extend({
 
         instance.allScoStates[instance.activeScoId]._finished = false;
         instance._navShown = false;
-        instance._scormAssessCounter = 0;
 
         var globalConfigObj = EkstepRendererAPI.getGlobalConfig();
         var prefix_url = isbrowserpreview
@@ -427,10 +496,28 @@ org.ekstep.contentrenderer.baseLauncher.extend({
             EkstepRendererAPI.dispatchEvent('renderer:next:hide');
             EkstepRendererAPI.dispatchEvent('renderer:previous:hide');
 
+            if (instance.maxAttemptsExceeded && !instance._maxAttemptsToastShown) {
+                instance._maxAttemptsToastShown = true;
+                instance.showMaxAttemptsToast();
+            }
+
             if (instance.scoList && instance.scoList.length > 1) {
                 instance.showMultiScoNavigation();
             }
         }, 100);
+    },
+
+    showMaxAttemptsToast: function () {
+        var toastHtml = '<div id="max-attempts-toast" style="position: fixed; top: 20px; left: 50%; transform: translateX(-50%); background: #fff3cd; border: 1px solid #ffc107; border-radius: 4px; padding: 16px 20px; box-shadow: 0 4px 6px rgba(0,0,0,0.1); z-index: 10000; display: flex; justify-content: space-between; align-items: center; max-width: 500px;">' +
+            '<span style="color: #856404; font-weight: 500; margin-right: 16px;">Attempts exhausted — this session will not be scored.</span>' +
+            '<button id="close-max-attempts-toast" style="background: none; border: none; cursor: pointer; color: #856404; font-size: 18px; padding: 0; width: 24px; height: 24px; display: flex; align-items: center; justify-content: center;">×</button>' +
+            '</div>';
+        jQuery('body').append(toastHtml);
+        jQuery('#close-max-attempts-toast').click(function () {
+            jQuery('#max-attempts-toast').fadeOut(300, function () {
+                jQuery(this).remove();
+            });
+        });
     },
 
     hasAttemptedCurrentSco: function () {
@@ -488,6 +575,7 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 if (!instance.hasAttemptedCurrentSco() && !window.confirm("You haven't attempted this section's quiz yet. Complete the course anyway?")) {
                     return;
                 }
+                instance.fireAggregatedAssess();
                 EkstepRendererAPI.dispatchEvent('renderer:content:end');
             });
         } else {

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/plugin.js
@@ -139,51 +139,16 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         };
 
         api[profile.methods.set] = function (k, v) {
-            var previousValue = instance.allScoStates[instance.activeScoId][k];
             instance.allScoStates[instance.activeScoId][k] = v;
 
-            // Each scoreKey set is its own complete, independent ASSESS event
-            // (mirrors QUML's one-ASSESS-per-question). A SCO may set the same
-            // value multiple times (idempotent autosave-style calls) - skip those.
-            if (k === profile.scoreKey && v !== previousValue) {
-                var telemetry = EkstepRendererAPI.getTelemetryService();
-                if (telemetry) {
-                    try {
-                        var state = instance.allScoStates[instance.activeScoId];
-                        var maxScoreValue = state[profile.scoreMaxKey];
-                        var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
-                        var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
-                        instance._scormAssessCounter = (instance._scormAssessCounter || 0) + 1;
-                        var qid = instance.activeScoId + '-' + instance._scormAssessCounter;
-                        var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
-                        var startEvent = telemetry.assess(
-                            qid,
-                            instance.data.subject || 'SCORM',
-                            'MEDIUM',
-                            { maxscore: maxScore }
-                        ).start();
-                        telemetry.assessEnd(startEvent, {
-                            pass: (statusValue === 'completed' || statusValue === 'passed'),
-                            score: v,
-                            qindex: instance._scormAssessCounter - 1,
-                            qtitle: activeSco ? activeSco.title : '',
-                            qdesc: '',
-                            res: [],
-                            mmc: [],
-                            mc: []
-                        });
-                    } catch (e) {
-                        console.error('SCORM: Unable to record ASSESS telemetry', e);
-                    }
-
-                    instance.fireTelemetry('INTERACT', {
-                        type: 'OTHER',
-                        subtype: 'SCORM_PROGRESS',
-                        id: 'scorm_progress',
-                        status: 'incomplete',
-                        scoId: instance.activeScoId
-                    });
-                }
+            if (k === profile.scoreKey) {
+                instance.fireTelemetry('INTERACT', {
+                    type: 'OTHER',
+                    subtype: 'SCORM_PROGRESS',
+                    id: 'scorm_progress',
+                    status: 'incomplete',
+                    scoId: instance.activeScoId
+                });
             }
 
             if (k === profile.statusKey || (profile.successKey && k === profile.successKey)) {
@@ -243,6 +208,40 @@ org.ekstep.contentrenderer.baseLauncher.extend({
                 }
             }
 
+            var currentScore = state[profile.scoreKey];
+            if (currentScore !== undefined && currentScore !== instance._lastReportedScore[instance.activeScoId]) {
+                var telemetry = EkstepRendererAPI.getTelemetryService();
+                if (telemetry) {
+                    try {
+                        var maxScoreValue = state[profile.scoreMaxKey];
+                        var maxScore = (maxScoreValue !== undefined && maxScoreValue !== null && maxScoreValue !== '') ? maxScoreValue : 100;
+                        var statusValue = state[profile.statusKey] || (profile.successKey && state[profile.successKey]);
+                        instance._scormAssessCounter = (instance._scormAssessCounter || 0) + 1;
+                        var qid = instance.activeScoId + '-' + instance._scormAssessCounter;
+                        var activeSco = instance.scoList && instance.scoList[instance.currentScoIndex];
+                        var startEvent = telemetry.assess(
+                            qid,
+                            instance.data.subject || 'SCORM',
+                            'MEDIUM',
+                            { maxscore: maxScore }
+                        ).start();
+                        telemetry.assessEnd(startEvent, {
+                            pass: (statusValue === 'completed' || statusValue === 'passed'),
+                            score: currentScore,
+                            qindex: instance._scormAssessCounter - 1,
+                            qtitle: activeSco ? activeSco.title : '',
+                            qdesc: '',
+                            res: [],
+                            mmc: [],
+                            mc: []
+                        });
+                        instance._lastReportedScore[instance.activeScoId] = currentScore;
+                    } catch (e) {
+                        console.error('SCORM: Unable to record ASSESS telemetry', e);
+                    }
+                }
+            }
+
             if (state._finished && instance.scoList && instance.scoList.length === 1) {
                 var overallStatus = instance.computeOverallStatus();
                 if (!instance.isUnloading && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
@@ -266,17 +265,25 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         var instance = this;
         instance.allScoStates[instance.activeScoId]._finished = true;
         var isLastSco = instance.currentScoIndex === instance.scoList.length - 1;
+        var isMultiSco = instance.scoList && instance.scoList.length > 1;
         if (isLastSco) {
+            var result = "true";
+            if (scormAPI && !instance._realFinishCalled) {
+                instance._realFinishCalled = true;
+                result = scormAPI[profile.methods.finish]("");
+            }
+            if (isMultiSco) {
+                instance._navShown = true;
+                instance.showMultiScoNavigation();
+                return String(result);
+            }
             var overallStatus = instance.computeOverallStatus();
-            var result = scormAPI
-                ? scormAPI[profile.methods.finish]("")
-                : "true";
             if (!instance.isUnloading && (result === "true" || result === true) && (overallStatus === 'completed' || overallStatus === 'passed' || overallStatus === 'failed')) {
                 EkstepRendererAPI.dispatchEvent('renderer:content:end');
             }
             return String(result);
         }
-        if (instance.scoList && instance.scoList.length > 1) {
+        if (isMultiSco) {
             instance.showMultiScoNavigation();
         }
         return "true";
@@ -295,6 +302,8 @@ org.ekstep.contentrenderer.baseLauncher.extend({
         instance.scoList = [];
         instance.currentScoIndex = 0;
         instance._scormAssessCounter = 0;
+        instance._lastReportedScore = {};
+        instance._realFinishCalled = false;
 
         var isMobile = window.cordova ? true : false;
         var envHTML = isMobile ? "app" : "portal";

--- a/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/scormProfiles.js
+++ b/player/public/coreplugins/org.ekstep.htmlrenderer-1.0/renderer/scormProfiles.js
@@ -6,6 +6,8 @@ window.SCORM_PROFILES = {
         scoreKey: 'cmi.core.score.raw',
         scoreMaxKey: 'cmi.core.score.max',
         exitKey: 'cmi.core.exit',
+        entryKey: 'cmi.core.entry',
+        modeKey: 'cmi.core.lesson_mode',
         defaultState: {
             'cmi.core.lesson_status': 'not attempted'
         },
@@ -35,6 +37,8 @@ window.SCORM_PROFILES = {
         scoreKey: 'cmi.score.raw',
         scoreMaxKey: 'cmi.score.max',
         exitKey: 'cmi.exit',
+        entryKey: 'cmi.entry',
+        modeKey: 'cmi.mode',
         defaultState: {
             'cmi.completion_status': 'unknown',
             'cmi.success_status': 'unknown'


### PR DESCRIPTION
## Summary

SCORM player fixes for multi-SCO navigation, assessment tracking, and progress reporting.

## Changes

- **fix:** multi-SCO navigation — show next/complete buttons only after quiz attempt; confirm before skipping untouched sections
- **fix:** assessment telemetry — emit ASSESS event per SCO with actual score/max-score; track last reported score to avoid dupes
- **fix:** total score calculation — only fire `renderer:content:end` when all SCOs complete (was premature on single-SCO finish)
- **fix:** progress tracking — expose SCORM API to iframe after load; reset assessment counter per SCO; add max-score to profiles (SCORM 1.2 + 2004)
- **refactor:** extract `hasAttemptedCurrentSco()` to gate nav buttons and prevent skipping unstarted quizzes

## Files changed

- `org.ekstep.htmlrenderer-1.0/renderer/plugin.js` — navigation, telemetry, state management
- `scormProfiles.js` — add `scoreMaxKey` to SCORM 1.2 & 2004 profiles

## Testing

- Multi-SCO course: attempt quiz → nav appears; skip unstarted → confirmation prompt
- Score updates: telemetry batches correctly; total reflects all section scores
- Single-SCO course: no behavior change (nav stays hidden)